### PR TITLE
feat: hash speaker e-mail address in map

### DIFF
--- a/devcon-api/src/clients/pretalx.ts
+++ b/devcon-api/src/clients/pretalx.ts
@@ -4,6 +4,7 @@ import { PRETALX_CONFIG } from '@/utils/config'
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import Parser from 'rss-parser'
+import { createHash } from 'crypto'
 
 dayjs.extend(utc)
 
@@ -139,6 +140,7 @@ function mapSpeaker(i: any, params: Partial<RequestParams>) {
   const lens = i.answers?.find((i: any) => i.question.id === PRETALX_CONFIG.PRETALX_QUESTIONS_LENS)?.answer
   const ens = i.answers?.find((i: any) => i.question.id === PRETALX_CONFIG.PRETALX_QUESTIONS_ENS)?.answer
   const telegram = i.answers?.find((i: any) => i.question.id === PRETALX_CONFIG.PRETALX_QUESTIONS_TELEGRAM)?.answer
+  const email = i.answers?.find((i: any) => i.question.id === PRETALX_CONFIG.PRETALX_QUESTIONS_EMAIL)?.answer
 
   let speaker: any = {
     id: defaultSlugify(i.name),
@@ -156,6 +158,7 @@ function mapSpeaker(i: any, params: Partial<RequestParams>) {
     const handle = sanitizeProfileField(ens)
     speaker.ens = handle.startsWith('0x') ? handle : handle.endsWith('.eth') ? handle : `${handle}.eth`
   }
+  if (notEmptyOrInvalid(email)) speaker.emailHash = hash(email)
 
   if (params.inclContacts && i.email) speaker.email = i.email
   if (params.inclContacts && notEmptyOrInvalid(telegram)) speaker.telegram = sanitizeProfileField(telegram)
@@ -207,6 +210,10 @@ function sanitizeProfileField(value: string) {
   value = value.replace('/', '')
 
   return value
+}
+
+function hash(secret: string) {
+  return createHash('sha256').update(secret).digest('hex')
 }
 
 function arrayify(value: string | undefined) {

--- a/devcon-api/src/db/schema.prisma
+++ b/devcon-api/src/db/schema.prisma
@@ -41,6 +41,7 @@ model Speaker {
   sourceId String
   name String
   avatar String
+  email_hash String?
   description String?
   twitter String?
   farcaster String?

--- a/devcon-api/src/db/schema.prisma
+++ b/devcon-api/src/db/schema.prisma
@@ -41,7 +41,7 @@ model Speaker {
   sourceId String
   name String
   avatar String
-  email_hash String?
+  emailHash String?
   description String?
   twitter String?
   farcaster String?

--- a/devcon-api/src/utils/config.ts
+++ b/devcon-api/src/utils/config.ts
@@ -60,6 +60,8 @@ export const PRETALX_CONFIG = {
   PRETALX_EVENT_NAME: 'devcon7-sea', // 'devcon-vi-2022' // 'pwa-data'
   PRETALX_EVENT_ID: 7,
 
+  // FIX ME: Update this fictional email question ID
+  PRETALX_QUESTIONS_EMAIL: 1337,
   PRETALX_QUESTIONS_GITHUB: 61,
   PRETALX_QUESTIONS_TWITTER: 62,
   PRETALX_QUESTIONS_WEBSITE: 63,


### PR DESCRIPTION
## What

Changes pretalx sync mechanism to extract speaker e-mail address and store value SHA256 hashed in public data.

## Why

Enables third parties an e-mail check without revealing the PII.

## TODO

- [ ] Change question field number
- [ ] Test locally
