### PR TITLE
Remove have a wonderful devcon

### DIFF
--- a/devcon-app/src/components/domain/app/dc7/dashboard/index.tsx
+++ b/devcon-app/src/components/domain/app/dc7/dashboard/index.tsx
@@ -147,7 +147,7 @@ const LoggedIn = () => {
           {account?.username ? `Welcome, ${account?.username}!` : 'Welcome!'} 👋
         </div>
         <p className="text-xs text-[#505050] mt-1">
-          Thank you for connecting to the Devcon Passport - have a wonderful Devcon.
+          Thank you for connecting to the Devcon Passport.
         </p>
       </div>
 


### PR DESCRIPTION
Devcon is over - so this sentence makes no sense anymore We can also change it to "Hope you had a great Devcon" or something like that - but I think this way it is cleaner