### PR TITLE
fix: update rtd card styling

### DIFF
--- a/devcon/src/components/domain/road-to-devcon/RoadToDevconPrograms.tsx
+++ b/devcon/src/components/domain/road-to-devcon/RoadToDevconPrograms.tsx
@@ -33,7 +33,7 @@ export function RoadToDevconPrograms() {
           {PROGRAMS.map(({ icon: Icon, to, key }) => (
             <div
               key={key}
-              className="flex flex-col gap-4 rounded-2xl border border-white/20 bg-[rgba(34,17,68,0.15)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]"
+              className="flex flex-col gap-4 rounded-2xl outline outline-white/20 bg-[rgba(34,17,68,0.15)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]"
             >
               <Icon size={32} strokeWidth={1.5} className="text-[#b08df5]" />
               <div className="flex flex-col gap-2">

--- a/devcon/src/pages/road-to-devcon.tsx
+++ b/devcon/src/pages/road-to-devcon.tsx
@@ -35,7 +35,7 @@ function ProgramCardItem({
   learnMore: string
 }) {
   return (
-    <div className="rounded-2xl border border-white/20 bg-[rgba(242,241,244,0.08)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]">
+    <div className="rounded-2xl outline outline-white/20 bg-[rgba(242,241,244,0.08)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]">
       {icon}
       <h3 className="mt-6 text-xl font-extrabold">{title}</h3>
       <p className="mt-2 text-sm font-light leading-relaxed text-white">{description}</p>


### PR DESCRIPTION
Borders on RTD program cards weren't displaying. Updated to use `outline` instead of `border`. 