### PR TITLE
feat: launch R2 ecosystem program

### DIFF
--- a/devcon/content/en/intl/ecosystem_program.json
+++ b/devcon/content/en/intl/ecosystem_program.json
@@ -13,7 +13,7 @@
     "body": "We fund local projects, events, and contributors creating spaces for learning, experimentation, and coordination on the road to Devcon 8 India.",
     "apply_button": "Apply now",
     "deadline_label": "Deadline to apply:",
-    "deadline_date": "30 April, 2026"
+    "deadline_date": "14 August, 2026"
   },
   "applications_closed": {
     "heading": "Round 1 has now closed",
@@ -79,8 +79,8 @@
   "budget_note": {
     "note_strong": "Note:",
     "note_body": " The program will run in two waves. In Wave 1, we prioritize initiatives with the greatest impact.",
-    "wave_label": "Wave 1 - RFP Closing Date:",
-    "wave_date": "30 April, 2026",
+    "wave_label": "Deadline to apply:",
+    "wave_date": "14 August, 2026",
     "apply_button": "Apply now",
     "footer_prefix": "After applying, please wait for our response — ",
     "footer_strong": "we'll get back to you within 15 days",

--- a/devcon/src/pages/ecosystem-program/ecosystem-program.module.scss
+++ b/devcon/src/pages/ecosystem-program/ecosystem-program.module.scss
@@ -49,15 +49,6 @@
     text-align: center;
     width: 100%;
   }
-
-  &::after {
-    content: '';
-    position: absolute;
-    inset: 0;
-    z-index: 1;
-    pointer-events: none;
-    box-shadow: inset 0 0 120px 40px rgba(0, 0, 0, 0.65);
-  }
 }
 
 .hero-title {
@@ -65,8 +56,9 @@
   font-weight: 400 !important;
   text-transform: none !important;
   font-size: clamp(3rem, 9vw, 130px) !important;
-  letter-spacing: -2px !important;
-  color: #f9f8fa !important;
+  letter-spacing: -3px !important;
+  color: #fff !important;
+  filter: drop-shadow(0 2px 4px rgba(0, 0, 0, 0.15)) drop-shadow(0 1px 2px rgba(0, 0, 0, 0.1));
   transform: translateY(-16px);
 
   @media (max-width: $breakpoints-md) {

--- a/devcon/src/pages/ecosystem-program/index.tsx
+++ b/devcon/src/pages/ecosystem-program/index.tsx
@@ -49,29 +49,31 @@ const APPLICATION_ROWS: ApplicationRow[] = [
   },
 ]
 
-function ApplicationsClosedCard() {
-  const t = useTranslations('ecosystem_program.applications_closed')
-  return (
-    <div className={css['applications-closed-card']}>
-      <div className={css['applications-closed-inner']}>
-        <div className={css['applications-closed-text']}>
-          <p className={css['applications-closed-heading']}>{t('heading')}</p>
-          <div className={css['applications-closed-body']}>
-            <p>{t('thank_you')}</p>
-            <p>
-              {t('deadline_prefix')}
-              <strong>{t('deadline_date')}</strong>
-            </p>
-          </div>
-        </div>
-        <div className={css['applications-closed-divider']} />
-        <p className={css['applications-closed-next']}>
-          {t('round_2_prefix')} <strong>{t('round_2_date')}</strong>
-        </p>
-      </div>
-    </div>
-  )
-}
+// Kept for re-closing the round: swap the two CTA blocks back for <ApplicationsClosedCard />
+// (intl keys live under ecosystem_program.applications_closed).
+// function ApplicationsClosedCard() {
+//   const t = useTranslations('ecosystem_program.applications_closed')
+//   return (
+//     <div className={css['applications-closed-card']}>
+//       <div className={css['applications-closed-inner']}>
+//         <div className={css['applications-closed-text']}>
+//           <p className={css['applications-closed-heading']}>{t('heading')}</p>
+//           <div className={css['applications-closed-body']}>
+//             <p>{t('thank_you')}</p>
+//             <p>
+//               {t('deadline_prefix')}
+//               <strong>{t('deadline_date')}</strong>
+//             </p>
+//           </div>
+//         </div>
+//         <div className={css['applications-closed-divider']} />
+//         <p className={css['applications-closed-next']}>
+//           {t('round_2_prefix')} <strong>{t('round_2_date')}</strong>
+//         </p>
+//       </div>
+//     </div>
+//   )
+// }
 
 export default function EcosystemProgramPage() {
   const t = useTranslations('ecosystem_program')
@@ -139,7 +141,14 @@ export default function EcosystemProgramPage() {
           </div>
 
           <div className={css['hero-cta-block']}>
-            <ApplicationsClosedCard />
+            <Link to="https://esp.ethereum.foundation/applicants/rfp/rtd8_india" className={css['btn-primary']}>
+              {t('hero.apply_button')}
+              <ArrowRight size={16} strokeWidth={2} />
+            </Link>
+            <div className={css['hero-deadline']}>
+              <span>{t('hero.deadline_label')}</span>
+              <strong>{t('hero.deadline_date')}</strong>
+            </div>
           </div>
         </section>
 
@@ -259,12 +268,16 @@ export default function EcosystemProgramPage() {
 
           {/* Budget Note + CTA */}
           <div id="apply" className={cn(css['budget-note'], css['scroll-anchor'])}>
-            <p className={css['body-small']}>
-              <strong>{t('budget_note.note_strong')}</strong>
-              {t('budget_note.note_body')}
-            </p>
-
-            <ApplicationsClosedCard />
+            <div className={css['wave-cta-row']}>
+              <div className={css['wave-cta-info']}>
+                <span>{t('budget_note.wave_label')}</span>
+                <span className={css['wave-cta-date']}>{t('budget_note.wave_date')}</span>
+              </div>
+              <Link to="https://esp.ethereum.foundation/applicants/rfp/rtd8_india" className={css['btn-primary']}>
+                {t('budget_note.apply_button')}
+                <ArrowRight size={16} strokeWidth={2} />
+              </Link>
+            </div>
 
             <p className={css['budget-note-footer']}>
               {t('budget_note.footer_prefix')}


### PR DESCRIPTION
Re-adds the 'Apply now' CTA's on /ecosystem-program as round two launches today, 7 July. Both CTA's link to dedicated ESP application form.

Other changes:
- Removes '_Note: This program_' text as it's now redundant
- Small styling tweaks to the hero art and typography