### PR TITLE
fix: update speaker apps closing date

### DIFF
--- a/devcon/content/en/intl/speaker_applications.json
+++ b/devcon/content/en/intl/speaker_applications.json
@@ -18,7 +18,7 @@
   "dates_bar": {
     "items": [
       { "label": "Applications open:", "value": "9 July" },
-      { "label": "Deadline:", "value": "4 August 2026, 23:59 UTC" },
+      { "label": "Deadline:", "value": "6 August 2026, 23:59 UTC" },
       { "label": "Decisions start:", "value": "End of August" }
     ]
   },
@@ -161,7 +161,7 @@
     "contact_prefix": "Got a question? Reach out to ",
     "contact_email": "speak@devcon.org",
     "closes_label": "Applications close",
-    "closes_date": "4 August, 2026",
+    "closes_date": "6 August, 2026",
     "apply_button": "Apply to speak"
   }
 }


### PR DESCRIPTION
Update the Speaker Applications closing date from 4 August to 6 August.