### PR TITLE
feat: update event images aspect ratio, page design tweaks

### DIFF
--- a/devcon/src/components/domain/road-to-devcon/RoadToDevconCommunities.tsx
+++ b/devcon/src/components/domain/road-to-devcon/RoadToDevconCommunities.tsx
@@ -43,7 +43,7 @@ export function RoadToDevconCommunities() {
             <p className="text-base font-medium text-[#1a0d33]">{t('communities.cta_text')}</p>
             <Link
               to={CONTACT_URL}
-              className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-full border border-[rgba(34,17,68,0.1)] bg-white/80 px-8 py-3.5 text-base font-bold text-[#1a0d33] transition-colors hover:bg-white sm:w-auto"
+              className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-full outline outline-1 outline-[#221144]/10 bg-white/80 px-8 py-3.5 text-base font-bold text-[#1a0d33] transition-[background-color,transform] duration-150 ease-out hover:scale-[1.03] hover:bg-white active:scale-[0.97] sm:w-auto"
             >
               {t('communities.cta_button')}
               <ArrowRight size={16} strokeWidth={2} />

--- a/devcon/src/components/domain/road-to-devcon/RoadToDevconEvents.tsx
+++ b/devcon/src/components/domain/road-to-devcon/RoadToDevconEvents.tsx
@@ -38,8 +38,9 @@ function EventCard({ event, dateLabel }: { event: RoadEvent; dateLabel: string }
       to={event.url ?? LISTING_FORM_URL}
       className="group flex flex-col overflow-hidden rounded-2xl outline outline-1 outline-[#221144]/10 bg-white transition-[box-shadow,transform] duration-150 ease-out hover:scale-[1.03] hover:shadow-md hover:shadow-[#221144]/10 active:scale-[0.97] active:shadow-none"
     >
-      {/* Standard social/OG image ratio (1200x630); height follows card width. */}
-      <div className={cn('relative aspect-[1200/630] w-full overflow-hidden bg-gradient-to-b', event.gradient)}>
+      {/* Standard 16:9 image ratio; height follows card width. Lets uploaders use a
+          standard size without cropping; object-cover still handles off-ratio images. */}
+      <div className={cn('relative aspect-video w-full overflow-hidden bg-gradient-to-b', event.gradient)}>
         {/* Only render an image when the event actually has one — otherwise the
             card's random gradient (on the container) shows through. unoptimized:
             images are pre-resized card WebPs served straight from Supabase's CDN
@@ -249,8 +250,13 @@ export function RoadToDevconEvents({ events }: { events: RoadEvent[] }) {
       {/* Co-hosted-by strip — text + logo in a row on desktop, stacked on mobile */}
       <div className="mt-8 flex flex-col items-center justify-center gap-x-4 gap-y-3 sm:flex-row">
         <p className="text-base font-medium text-[#221144]">{t('events.cohosted_by')}</p>
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img src="/road-to-devcon/geode-labs.png" alt="Geode Labs" className="h-10 w-auto object-contain" />
+        <Link
+          to="https://geode.build/"
+          className="inline-flex cursor-pointer transition-transform duration-150 ease-out hover:scale-[1.03]"
+        >
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src="/road-to-devcon/geode-labs.png" alt="Geode Labs" className="h-10 w-auto object-contain" />
+        </Link>
       </div>
 
       {/* "Get listed" CTA */}
@@ -258,7 +264,7 @@ export function RoadToDevconEvents({ events }: { events: RoadEvent[] }) {
         <p className="text-center text-lg font-extrabold text-[#160b2b] sm:text-xl">{t('events.cta_text')}</p>
         <Link
           to={LISTING_FORM_URL}
-          className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-full bg-[#7235ed] px-8 py-3.5 text-base font-bold text-white transition-colors hover:bg-[#5f23d6] md:w-auto"
+          className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-full bg-[#7235ed] px-8 py-3.5 text-base font-bold text-white transition-[background-color,transform] duration-150 ease-out hover:scale-[1.03] hover:bg-[#5f23d6] active:scale-[0.97] md:w-auto"
         >
           {t('events.cta_button')}
         </Link>

--- a/devcon/src/components/domain/road-to-devcon/RoadToDevconPrograms.tsx
+++ b/devcon/src/components/domain/road-to-devcon/RoadToDevconPrograms.tsx
@@ -33,7 +33,7 @@ export function RoadToDevconPrograms() {
           {PROGRAMS.map(({ icon: Icon, to, key }) => (
             <div
               key={key}
-              className="flex flex-col gap-4 rounded-2xl outline outline-white/20 bg-[rgba(34,17,68,0.15)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]"
+              className="flex flex-col gap-4 rounded-2xl outline outline-1 outline-white/20 bg-[rgba(34,17,68,0.15)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]"
             >
               <Icon size={32} strokeWidth={1.5} className="text-[#b08df5]" />
               <div className="flex flex-col gap-2">

--- a/devcon/src/pages/road-to-devcon.tsx
+++ b/devcon/src/pages/road-to-devcon.tsx
@@ -34,7 +34,7 @@ function ProgramCardItem({
   learnMore: string
 }) {
   return (
-    <div className="rounded-2xl outline outline-white/20 bg-[rgba(242,241,244,0.08)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]">
+    <div className="rounded-2xl outline outline-1 outline-white/20 bg-[rgba(242,241,244,0.08)] p-6 shadow-[0_2px_8px_0_rgba(34,17,68,0.15)] backdrop-blur-[6px]">
       {icon}
       <h3 className="mt-6 text-xl font-extrabold">{title}</h3>
       <p className="mt-2 text-sm font-light leading-relaxed text-white">{description}</p>


### PR DESCRIPTION
- Update event images aspect ratio to 16:9 for better compatibility
- Add Geode Labs link and interaction on logo
- Fix default `outline` prop behavior by specifying `outline-1` on program cards
- Add scale effect to button hover and pressed states