### PR TITLE
closing GA sales

### DIFF
--- a/devcon/src/config/waves.ts
+++ b/devcon/src/config/waves.ts
@@ -81,7 +81,7 @@ export const CURRENT_WAVE_ID = 'wave-ga'
 // The overview / comparison tags flip to match. Nothing else needs editing.
 // Preview: `?mockNow=coming-soon` or `?mockNow=closed`.
 export type GaSaleState = 'open' | 'coming-soon' | 'closed'
-export const GA_SALE_STATE: GaSaleState = 'open'
+export const GA_SALE_STATE: GaSaleState = 'closed'
 
 // Time the 'coming-soon' state counts down to. Defaults to the global launch
 // (14 Jul 2026, 16:00 UTC) so the surfaces read "Available on Jul 14, 16:00


### PR DESCRIPTION
FYI @Scott1UP for when we want to close the GA sales, just merge this PR.

# GA sale state: how it works and how to change it

## What this change does

One line changed in `devcon/src/config/waves.ts` (line 84):

```ts
export const GA_SALE_STATE: GaSaleState = 'closed'   // was 'open'
```

Merging this closes the General Admission sale on devcon.org: the GA row on `/tickets` shows **"Reopens August"** with no countdown, the "Get tickets" CTA disappears (the price stays visible), and the hero, strip, overview tags, comparison table, and the store page all flip automatically. Nothing else needs editing for a state change.

## The system in one paragraph

`src/config/waves.ts` is the single source of truth. `CURRENT_WAVE_ID` points at the wave that is "the active sale" (currently `wave-ga`). Waves before it in the list show "Sale ended", waves after it show as upcoming. The current wave's status is driven entirely by the manual `GA_SALE_STATE` switch. There is no automatic date or availability logic behind it: changing the state means editing this constant and deploying.

## The three states

| `GA_SALE_STATE` | What visitors see                                                                                                           | When to use                                  |
| --------------- | --------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------- |
| `'open'`        | Price + "Get tickets" CTA, sale banner live                                                                                 | Selling normally                             |
| `'coming-soon'` | Badge "Coming soon" + a live countdown to `GA_COMING_SOON_OPENS_AT` (e.g. "available in 5d 20h"). CTA hidden, price visible | Reopening at a **known** date/time           |
| `'closed'`      | Static label "Reopens August". No timer. CTA hidden, price visible                                                          | Reopening later, **no exact time** announced |

## Customizing the labels and countdown

All in `src/config/waves.ts`, right below the switch:

```ts
export const GA_COMING_SOON_OPENS_AT: Date | null = GLOBAL_LAUNCH_TIME
export const GA_COMING_SOON_LABEL = 'Coming soon'
export const GA_CLOSED_LABEL = 'Reopens August'
```

- **"Reopens August"** text: edit `GA_CLOSED_LABEL`. Shown whenever the state is `'closed'`.
- **"Coming soon"** text: edit `GA_COMING_SOON_LABEL`. Note this is only a fallback: in `'coming-soon'` the surfaces normally show a countdown instead, and this label appears only if `GA_COMING_SOON_OPENS_AT` is null or already in the past.
- **The countdown target**: set `GA_COMING_SOON_OPENS_AT` to the reopen moment (a UTC `Date`). It currently points at the July 14 launch, so **if you flip to `'coming-soon'` for the August round, you must set this to the new date**, otherwise there is no timer and only the fallback label shows.
- Prices, wave names, and row details live in the `TICKET_WAVES` array in the same file.

## Important: this only closes the website

The Pretix shop at tickets.devcon.org is independent. Anyone with a direct link can still buy GA until the Pretix side is closed too (deactivate the GA item or set its quota to 0 in the Pretix admin). For a real sale pause, do both; for reopening, reverse both.