### PR TITLE
feat: Add dedicated Sanctuary Tech Builder application approval email

### DIFF
--- a/devcon/src/pages/api/builder/review/[id].ts
+++ b/devcon/src/pages/api/builder/review/[id].ts
@@ -28,7 +28,9 @@ interface MatchedRepo {
 // POST -> { decision: 'Approved' | 'Rejected' }. On Approve: mints a single-use
 //         builder voucher, emails it to the applicant, and records the code +
 //         Voucher Sent on the row. issueVoucher is idempotent per identity, so
-//         re-approving returns the same code rather than minting a duplicate.
+//         re-approving returns the same code rather than minting a duplicate —
+//         and the email is only sent once (skipped when Voucher Sent is already
+//         set, mirroring the reject-side transition guard).
 export default async function handler(req: NextApiRequest, res: NextApiResponse) {
   // Review data + live enrichment must always be current — never cache.
   res.setHeader('Cache-Control', 'no-store, max-age=0')
@@ -200,7 +202,13 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return
     }
 
-    const result = await issueBuilderVoucher(email, builderIdentities(record), String(record['Full Name'] || ''))
+    // Only email on the transition INTO Approved (like the reject side) — but
+    // keyed on Voucher Sent rather than Decision alone, so a failed first send
+    // can still be retried by re-approving.
+    const alreadyEmailed = record['Decision'] === 'Approved' && Boolean(record['Voucher Sent'])
+    const result = await issueBuilderVoucher(email, builderIdentities(record), String(record['Full Name'] || ''), {
+      skipEmail: alreadyEmailed,
+    })
     if (!result.ok) {
       if (result.error === 'not-configured') {
         res.status(500).json({ success: false, error: 'Builder discount is not configured (no Pretix item).' })
@@ -217,7 +225,8 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
     await updateRow(VIEW_ID, id, {
       Decision: 'Approved',
       'Voucher Code': result.code,
-      'Voucher Sent': result.emailed,
+      // Never downgrade the flag: a skipped (deduped) send returns emailed=false.
+      'Voucher Sent': result.emailed || Boolean(record['Voucher Sent']),
       ...noteUpdate,
     })
 

--- a/devcon/src/pages/api/builder/review/[id].ts
+++ b/devcon/src/pages/api/builder/review/[id].ts
@@ -200,7 +200,7 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       return
     }
 
-    const result = await issueBuilderVoucher(email, builderIdentities(record))
+    const result = await issueBuilderVoucher(email, builderIdentities(record), String(record['Full Name'] || ''))
     if (!result.ok) {
       if (result.error === 'not-configured') {
         res.status(500).json({ success: false, error: 'Builder discount is not configured (no Pretix item).' })

--- a/devcon/src/services/builder/email.ts
+++ b/devcon/src/services/builder/email.ts
@@ -54,6 +54,14 @@ function buildApprovalHtml(name: string, voucherCode: string): string {
                   Redeem your discount
                 </a>
               </div>
+              <div style="background: #f2f1f4; border-radius: 12px; padding: 20px; text-align: center; margin-bottom: 24px;">
+                <p style="margin: 0 0 4px; font-size: 12px; font-weight: 600; color: #594d73; text-transform: uppercase; letter-spacing: 1px;">
+                  DISCOUNT CODE
+                </p>
+                <p style="margin: 0; font-size: 20px; font-weight: 800; color: #7235ed; letter-spacing: 1px;">
+                  ${escapeHtml(voucherCode)}
+                </p>
+              </div>
               <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
                 <strong>Please redeem this voucher within 1 month of receiving this email!</strong>
               </p>

--- a/devcon/src/services/builder/email.ts
+++ b/devcon/src/services/builder/email.ts
@@ -1,13 +1,92 @@
 /**
- * Builder application emails (rejection notice).
- * Approvals are handled by the voucher email (services/voucherEmail.ts).
+ * Builder application emails (approval + rejection notices).
  */
 
 import { sendMail } from 'services/mailer'
+import { pretixEventUrl } from 'config/ticketing'
 
 // Escape applicant-supplied text before interpolating it into the email HTML.
 function escapeHtml(s: string): string {
   return s.replace(/[&<>"']/g, c => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[c] as string)
+}
+
+function buildApprovalHtml(name: string, voucherCode: string): string {
+  const greeting = name ? `Hi ${escapeHtml(name)},` : 'Hi,'
+  // Deep-link straight to the Pretix store with the voucher pre-applied.
+  const redeemUrl = pretixEventUrl(`/redeem?voucher=${encodeURIComponent(voucherCode)}`)
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Your Sanctuary Tech Builder application has been approved</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f3f7; font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f3f7; padding: 40px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 560px; background: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 2px 8px rgba(22, 11, 43, 0.08);">
+          <!-- Header -->
+          <tr>
+            <td style="background: #1a0d33 url('https://devcon.org/email/header-bg.png') center/cover no-repeat; padding: 32px 32px 24px; text-align: center;">
+              <img src="https://devcon.org/email/devcon-logo-white.svg" alt="Devcon 8 India" width="149" height="64" style="display: inline-block; max-width: 149px;" />
+              <p style="margin: 12px 0 0; font-size: 14px; color: #ffffff;">
+                Sanctuary Tech Builders application update
+              </p>
+            </td>
+          </tr>
+          <!-- Body -->
+          <tr>
+            <td style="padding: 32px;">
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                ${greeting}
+              </p>
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                We're pleased to let you know that <strong>we approved your application for a Sanctuary Tech
+                Builder Discount to Devcon 8</strong>!
+              </p>
+              <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                You can use the button below to redeem your discount:
+              </p>
+              <div style="text-align: center; margin-bottom: 24px;">
+                <a href="${redeemUrl}" style="display: inline-block; padding: 14px 32px; font-size: 16px; font-weight: 700; color: #ffffff; background-color: #7235ed; border-radius: 9999px; text-decoration: none;">
+                  Redeem your discount
+                </a>
+              </div>
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                <strong>Please redeem this voucher within 1 month of receiving this email!</strong>
+              </p>
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                If you miss the redemption window for the voucher, contact us at
+                <a href="mailto:support@devcon.org" style="color: #7235ed;">support@devcon.org</a> &amp; we'll
+                revalidate it if there is still availability.
+              </p>
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                <strong>Note</strong>: If you already ordered a ticket &amp; would like to use this discounted
+                one instead, you'll need to go back to your original order confirmation page &amp; click
+                <strong>Cancel Order</strong> at the bottom.
+              </p>
+              <p style="margin: 0; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                We look forward to seeing you in Mumbai!
+              </p>
+            </td>
+          </tr>
+          <!-- Footer -->
+          <tr>
+            <td style="padding: 24px 32px; background: #f9f8fa; border-top: 1px solid #dddae2; text-align: center;">
+              <p style="margin: 0; font-size: 13px; color: #594d73; line-height: 1.5;">
+                Best,<br />
+                The Devcon Team 💜
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
 }
 
 function buildRejectionHtml(name: string): string {
@@ -71,6 +150,20 @@ function buildRejectionHtml(name: string): string {
   </table>
 </body>
 </html>`
+}
+
+/** Email an applicant that their builder application was approved, with their voucher code. */
+export async function sendBuilderApprovalEmail(
+  email: string,
+  voucherCode: string,
+  name?: string
+): Promise<{ success: boolean; error?: string }> {
+  return sendMail({
+    to: email.trim(),
+    subject: 'Your Sanctuary Tech Builder application has been approved 🎉',
+    html: buildApprovalHtml((name || '').trim(), voucherCode.trim()),
+    fromName: 'Devcon',
+  })
 }
 
 /** Email an applicant that their builder application was not approved. */

--- a/devcon/src/services/builder/voucher.ts
+++ b/devcon/src/services/builder/voucher.ts
@@ -5,7 +5,7 @@ import {
   setVoucherEmailSent,
   DiscountSoldOutError,
 } from 'services/discountStore'
-import { sendVoucherEmail } from 'services/voucherEmail'
+import { sendBuilderApprovalEmail } from 'services/builder/email'
 import { discountItem, discountCollection } from 'config/ticketing'
 
 export const BUILDER_DISCOUNT_TYPE = 'builder'
@@ -30,7 +30,7 @@ export type IssueResult =
  * person: if any of their identities already holds a voucher (any program), it's
  * reused instead of minting a second.
  */
-export async function issueBuilderVoucher(email: string, identities: string[]): Promise<IssueResult> {
+export async function issueBuilderVoucher(email: string, identities: string[], name?: string): Promise<IssueResult> {
   const itemId = discountItem(BUILDER_DISCOUNT_TYPE)
   if (!itemId) return { ok: false, error: 'not-configured' }
 
@@ -53,16 +53,16 @@ export async function issueBuilderVoucher(email: string, identities: string[]): 
 
   let emailed = false
   try {
-    const sent = await sendVoucherEmail(email, voucher.code)
+    const sent = await sendBuilderApprovalEmail(email, voucher.code, name)
     if (sent.success) {
       await setVoucherEmail(voucher.code, email)
       await setVoucherEmailSent(voucher.code)
       emailed = true
     } else {
-      console.warn('[builder voucher] sendVoucherEmail failed:', sent.error)
+      console.warn('[builder voucher] sendBuilderApprovalEmail failed:', sent.error)
     }
   } catch (err) {
-    console.warn('[builder voucher] sendVoucherEmail threw:', err)
+    console.warn('[builder voucher] sendBuilderApprovalEmail threw:', err)
   }
 
   return { ok: true, code: voucher.code, emailed, reused }

--- a/devcon/src/services/builder/voucher.ts
+++ b/devcon/src/services/builder/voucher.ts
@@ -28,9 +28,15 @@ export type IssueResult =
  * Mint (or reuse) a builder voucher for this applicant and email it. Shared by
  * the admin Approve action and the submit-time auto-approve. One voucher per
  * person: if any of their identities already holds a voucher (any program), it's
- * reused instead of minting a second.
+ * reused instead of minting a second. Pass skipEmail when the applicant was
+ * already notified, so the voucher still resolves without a duplicate email.
  */
-export async function issueBuilderVoucher(email: string, identities: string[], name?: string): Promise<IssueResult> {
+export async function issueBuilderVoucher(
+  email: string,
+  identities: string[],
+  name?: string,
+  opts?: { skipEmail?: boolean }
+): Promise<IssueResult> {
   const itemId = discountItem(BUILDER_DISCOUNT_TYPE)
   if (!itemId) return { ok: false, error: 'not-configured' }
 
@@ -52,17 +58,19 @@ export async function issueBuilderVoucher(email: string, identities: string[], n
   if (!voucher) return { ok: false, error: 'exhausted' }
 
   let emailed = false
-  try {
-    const sent = await sendBuilderApprovalEmail(email, voucher.code, name)
-    if (sent.success) {
-      await setVoucherEmail(voucher.code, email)
-      await setVoucherEmailSent(voucher.code)
-      emailed = true
-    } else {
-      console.warn('[builder voucher] sendBuilderApprovalEmail failed:', sent.error)
+  if (!opts?.skipEmail) {
+    try {
+      const sent = await sendBuilderApprovalEmail(email, voucher.code, name)
+      if (sent.success) {
+        await setVoucherEmail(voucher.code, email)
+        await setVoucherEmailSent(voucher.code)
+        emailed = true
+      } else {
+        console.warn('[builder voucher] sendBuilderApprovalEmail failed:', sent.error)
+      }
+    } catch (err) {
+      console.warn('[builder voucher] sendBuilderApprovalEmail threw:', err)
     }
-  } catch (err) {
-    console.warn('[builder voucher] sendBuilderApprovalEmail threw:', err)
   }
 
   return { ok: true, code: voucher.code, emailed, reused }

--- a/devcon/src/services/builder/voucher.ts
+++ b/devcon/src/services/builder/voucher.ts
@@ -25,11 +25,11 @@ export type IssueResult =
   | { ok: false; error: 'not-configured' | 'sold-out' | 'exhausted' | 'failed' }
 
 /**
- * Mint (or reuse) a builder voucher for this applicant and email it. Shared by
- * the admin Approve action and the submit-time auto-approve. One voucher per
- * person: if any of their identities already holds a voucher (any program), it's
- * reused instead of minting a second. Pass skipEmail when the applicant was
- * already notified, so the voucher still resolves without a duplicate email.
+ * Mint (or reuse) a builder voucher for this applicant and email it. Used by
+ * the admin Approve action. One voucher per person: if any of their identities
+ * already holds a voucher (any program), it's reused instead of minting a
+ * second. Pass skipEmail when the applicant was already notified, so the
+ * voucher still resolves without a duplicate email.
  */
 export async function issueBuilderVoucher(
   email: string,

--- a/devcon/src/services/voucherEmail.ts
+++ b/devcon/src/services/voucherEmail.ts
@@ -1,7 +1,8 @@
 /**
  * Voucher Email Service
  * Sends voucher confirmation emails via AWS SES SMTP.
- * Used by both the redeem-self backend (automatic) and send-voucher-email API (manual re-send).
+ * Used by the send-voucher-email API (manual re-send from the ticket-store redeem page).
+ * Builder approvals use their own template (services/builder/email.ts).
  */
 
 import { validateVoucher, getTicketPurchaseInfo } from 'services/pretix'


### PR DESCRIPTION
## Dedicated approval email for Sanctuary Tech Builder applications

### What & why
Previously, approving a builder application sent the applicant the generic voucher email (`services/voucherEmail.ts`) — the same template used by the ticket-store's manual re-send flow. Builders now get a dedicated approval email with program-specific copy (as requested by Ticketing), and the shared template is untouched for its remaining consumer.

### Changes
- `services/builder/email.ts` — new `sendBuilderApprovalEmail(email, voucherCode, name?)` + HTML template, built alongside the existing rejection email and reusing its layout/`escapeHtml`/`sendMail` plumbing.
  - Subject: `Your Sanctuary Tech Builder application has been approved 🎉`
  - Personalized greeting; "Redeem your discount" button deep-links to Pretix via `pretixEventUrl('/redeem?voucher=<code>')` (voucher pre-applied, visible code block available as a backup)
  - Notes the 1-month redemption window, points to support@devcon.org for revalidation (sender is noreply, so no reply-to), and explains the cancel-and-rebuy flow for people who already bought a ticket
- services/builder/voucher.ts — `issueBuilderVoucher()` now sends the new email; gains an optional `name` param. Voucher minting/reuse and `setVoucherEmail/setVoucherEmailSent` bookkeeping unchanged.
-` api/builder/review/[id].ts` — passes the application's Full Name through for the greeting.
- `services/voucherEmail.ts `— comment-only: header now correctly documents its single consumer (the send-voucher-email re-send API) and points builder approvals to the new template.

### Not changed / behavior notes
- Non-builder voucher emails (ticket-store re-send) are unaffected.
- Rejection email untouched.
- Approval email has no Pretix price fetch (copy has no price line), so approvals no longer depend on Pretix availability to send.
- Re-clicking Approve re-sends the email with the same reused voucher (the old path had a 5-min dedup; not needed for a deliberate admin action).

### Testing

- `tsc --noEmit` clean for changed files.
- Rendered the email through the real send path with `sendMail` stubbed: verified subject/emoji, greeting interpolation with HTML escaping, redeem deep-link, mailto link, and bold formatting.