### PR TITLE
feat: add travel guide to nav, improve language selector UX

### DIFF
--- a/devcon/content/en/intl/common.json
+++ b/devcon/content/en/intl/common.json
@@ -6,6 +6,7 @@
     "faq": "FAQ",
     "attend": "Attend",
     "tickets": "Tickets",
+    "travel_guide": "Travel Guide",
     "devcon_8_india": "Devcon 8 India",
     "submit_dip": "Submit a DIP",
     "get_involved": "Get Involved",

--- a/devcon/src/components/common/layouts/header/header.module.scss
+++ b/devcon/src/components/common/layouts/header/header.module.scss
@@ -99,10 +99,20 @@
     transition: --nav-grad-from 0.6s cubic-bezier(0.22, 1, 0.36, 1), --nav-grad-to 0.6s cubic-bezier(0.22, 1, 0.36, 1), box-shadow 0.6s cubic-bezier(0.22, 1, 0.36, 1), color 0.6s cubic-bezier(0.22, 1, 0.36, 1);
   }
 
+  // transform is included because this shorthand outranks .nav-chevron's own
+  // transition (navigation.module.scss) — without it the chevron rotation
+  // snaps on hero pages while animating everywhere else
   :global(.lucide-chevron-down),
   :global(.lucide-chevron-up) {
-    transition: color 0.2s ease, stroke 0.2s ease;
+    transition: color 0.2s ease, stroke 0.2s ease, transform 200ms ease;
     stroke: white !important;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    :global(.lucide-chevron-down),
+    :global(.lucide-chevron-up) {
+      transition: color 0.2s ease, stroke 0.2s ease;
+    }
   }
 
   &.filled {

--- a/devcon/src/components/common/layouts/header/menu/language-toggle/LanguageToggle.tsx
+++ b/devcon/src/components/common/layouts/header/menu/language-toggle/LanguageToggle.tsx
@@ -2,6 +2,8 @@ import React from 'react'
 import NextLink from 'next/link'
 import { useRouter } from 'next/router'
 import { Globe, ChevronDown } from 'lucide-react'
+import useIsTouchDevice from 'hooks/useIsTouchDevice'
+import css from './language-toggle.module.scss'
 
 const LOCALES = [
   { code: 'en', label: 'English', short: 'EN' },
@@ -11,10 +13,44 @@ const LOCALES = [
 
 type LocaleCode = (typeof LOCALES)[number]['code']
 
+// Matches the .menu-closing transition duration and the nav foldout close
+// grace period (FOLDOUT_CLOSE_MS in Navigation.tsx)
+const CLOSE_MS = 150
+
 export function LanguageToggle() {
   const router = useRouter()
+  const isTouchDevice = useIsTouchDevice()
+  // Target state; drives the closing transition while the menu stays mounted
   const [open, setOpen] = React.useState(false)
+  // Keeps the menu mounted until the close transition finishes
+  const [rendered, setRendered] = React.useState(false)
   const ref = React.useRef<HTMLDivElement>(null)
+  const closeTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const openMenu = () => {
+    if (closeTimerRef.current) {
+      clearTimeout(closeTimerRef.current)
+      closeTimerRef.current = null
+    }
+    setOpen(true)
+    setRendered(true)
+  }
+
+  // Re-opening mid-close retargets the transition instead of restarting it
+  const closeMenu = () => {
+    setOpen(false)
+    if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    closeTimerRef.current = setTimeout(() => {
+      setRendered(false)
+      closeTimerRef.current = null
+    }, CLOSE_MS)
+  }
+
+  React.useEffect(() => {
+    return () => {
+      if (closeTimerRef.current) clearTimeout(closeTimerRef.current)
+    }
+  }, [])
 
   const currentCode: LocaleCode =
     router.locale === 'hi' ? 'hi' : router.locale === 'mr' ? 'mr' : 'en'
@@ -23,10 +59,10 @@ export function LanguageToggle() {
   React.useEffect(() => {
     if (!open) return
     const onMouseDown = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+      if (ref.current && !ref.current.contains(e.target as Node)) closeMenu()
     }
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setOpen(false)
+      if (e.key === 'Escape') closeMenu()
     }
     document.addEventListener('mousedown', onMouseDown)
     document.addEventListener('keydown', onKey)
@@ -37,10 +73,21 @@ export function LanguageToggle() {
   }, [open])
 
   return (
-    <div id="language-toggle" ref={ref} className="relative text-sm font-bold ml-3">
+    <div
+      id="language-toggle"
+      ref={ref}
+      className="relative self-stretch flex items-center text-sm font-bold ml-3"
+      // Touch fires synthetic mouseenter on tap and clears hover right after
+      // (mouseleave), which would open-then-close the menu — hover is
+      // pointer-only, touch uses the click toggle below
+      onMouseEnter={isTouchDevice ? undefined : openMenu}
+      onMouseLeave={isTouchDevice ? undefined : closeMenu}
+    >
       <button
         type="button"
-        onClick={() => setOpen(v => !v)}
+        // Pointer: hover has already opened it, so click just re-opens
+        // (a toggle would close what the hover opened). Touch: tap toggles.
+        onClick={() => (isTouchDevice && open ? closeMenu() : openMenu())}
         aria-haspopup="menu"
         aria-expanded={open}
         aria-label="Select language"
@@ -56,26 +103,30 @@ export function LanguageToggle() {
           }}
         />
       </button>
-      {open && (
-        <div
-          role="menu"
-          className="absolute right-0 top-full mt-1 min-w-[140px] bg-white shadow-lg rounded-md border border-gray-200 z-50 overflow-hidden"
-        >
-          {LOCALES.map(l => {
-            const isActive = l.code === currentCode
-            return (
-              <NextLink
-                key={l.code}
-                href={router.asPath}
-                locale={l.code}
-                role="menuitem"
-                onClick={() => setOpen(false)}
-                className={`block px-3 py-2 text-sm text-gray-900 hover:bg-gray-100 ${isActive ? 'font-bold bg-gray-50' : 'font-normal'}`}
-              >
-                {l.label}
-              </NextLink>
-            )
-          })}
+      {rendered && (
+        // The 8px padding-top is the hover bridge across the visual gap
+        // between the nav bar and the card, same as the nav foldouts
+        <div className="absolute right-0 top-full pt-2 z-50">
+          <div
+            role="menu"
+            className={`${css['menu-card']} ${!open ? css['menu-closing'] : ''} min-w-[140px] bg-white shadow-lg rounded-md border border-gray-200 overflow-hidden`}
+          >
+            {LOCALES.map(l => {
+              const isActive = l.code === currentCode
+              return (
+                <NextLink
+                  key={l.code}
+                  href={router.asPath}
+                  locale={l.code}
+                  role="menuitem"
+                  onClick={closeMenu}
+                  className={`block px-3 py-2 text-sm text-gray-900 hover:bg-[#E5D9FC] ${isActive ? 'font-bold bg-[#E5D9FC]' : 'font-normal'}`}
+                >
+                  {l.label}
+                </NextLink>
+              )
+            })}
+          </div>
         </div>
       )}
     </div>

--- a/devcon/src/components/common/layouts/header/menu/language-toggle/language-toggle.module.scss
+++ b/devcon/src/components/common/layouts/header/menu/language-toggle/language-toggle.module.scss
@@ -1,0 +1,31 @@
+// Enter/exit mirrors the nav foldouts (navigation.module.scss): keyframe
+// appear on open, transition-based close so re-hovering mid-close retargets
+.menu-card {
+  transform-origin: top right;
+  animation: menuAppear 200ms cubic-bezier(0.32, 0.72, 0, 1);
+  transition: opacity 150ms ease-in, transform 150ms ease-in;
+}
+
+// Duration must match CLOSE_MS in LanguageToggle.tsx
+.menu-closing {
+  opacity: 0;
+  transform: translateY(-8px);
+}
+
+@keyframes menuAppear {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .menu-card {
+    transition: none;
+    animation: none;
+  }
+}

--- a/devcon/src/components/common/layouts/header/useNavigationData.ts
+++ b/devcon/src/components/common/layouts/header/useNavigationData.ts
@@ -55,7 +55,11 @@ const useNavigationData = () => {
             url: '/tickets',
             type: 'page',
           },
-          // Travel Guide lands here once its page merges
+          {
+            title: t('travel_guide'),
+            url: '/travel-guide',
+            type: 'page',
+          },
         ],
       },
       {


### PR DESCRIPTION
- Add Travel Guide link to the Attend dropdown (desktop + mobile), with new `common.nav.travel_guide` intl key (en only; translations via the usual action).
- Language selector now matches the nav foldouts: opens on hover, menu sits 8px below the nav bar, same enter/exit fade and hover/selected color (#E5D9FC). Touch keeps tap-to-toggle (hover handlers disabled via `useIsTouchDevice`).
- Fix nav chevron rotation snapping on hero pages: a header-level transition shorthand overrode `.nav-chevron` — added transform 200ms ease there, with reduced-motion override.