### PR TITLE
feat: add 'childcare' page

### DIFF
--- a/devcon/src/pages/api/sitemap.ts
+++ b/devcon/src/pages/api/sitemap.ts
@@ -14,6 +14,7 @@ const ROUTES = [
   { path: 'blogs/', changefreq: 'weekly', priority: '0.8' },
   { path: 'about/', changefreq: 'monthly', priority: '0.6' },
   { path: 'academic-program/', changefreq: 'monthly', priority: '0.6' },
+  { path: 'childcare/', changefreq: 'monthly', priority: '0.6' },
   { path: 'application-guidelines/', changefreq: 'monthly', priority: '0.6' },
   { path: 'code-of-conduct/', changefreq: 'monthly', priority: '0.6' },
   { path: 'dips/', changefreq: 'monthly', priority: '0.6' },

--- a/devcon/src/pages/childcare.module.scss
+++ b/devcon/src/pages/childcare.module.scss
@@ -1,0 +1,452 @@
+@use 'assets/css/partials/index' as *;
+
+/* ─── Hero Override (PageHero) ────────────────────────────── */
+/* Same treatment as tickets/faq.module.scss — full-bleed hero image,
+   no side gradient, centered Chloe title. */
+
+.hero-no-side-gradient {
+  --theme-gradient-background-color: transparent !important;
+  --theme-gradient: none !important;
+
+  [class*='background-layer-theme'] {
+    display: none !important;
+  }
+
+  background: #fff;
+
+  [class*='background-image'] {
+    mask-image: none !important;
+    -webkit-mask-image: none !important;
+    width: 100% !important;
+    left: 0 !important;
+
+    img {
+      object-position: center 70% !important;
+
+      @media (max-width: $breakpoints-md) {
+        object-position: center 50% !important;
+      }
+    }
+  }
+
+  [class*='background-layer'] :global(.section) {
+    display: block !important;
+  }
+
+  [data-type='page-hero-content'] {
+    position: relative;
+    height: 564px !important;
+    max-height: 564px !important;
+  }
+
+  [data-type='page-hero-content'] > * {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+
+  [data-type='page-hero-title-block'] {
+    text-align: center;
+    width: 100%;
+  }
+}
+
+.hero-title {
+  font-family: 'Chloe' !important;
+  font-weight: 400 !important;
+  text-transform: none !important;
+  font-size: clamp(3rem, 9vw, 130px) !important;
+  letter-spacing: -2px !important;
+  color: #f9f8fa !important;
+  text-shadow: 0px 2px 8px rgba(0, 0, 0, 0.15), 0px 1px 4px rgba(0, 0, 0, 0.1);
+  transform: translateY(-16px);
+
+  @media (max-width: $breakpoints-md) {
+    font-size: clamp(4rem, 20vw, 7rem) !important;
+  }
+}
+
+$content-max-width: 1120px;
+
+/* ─── Intro Band ──────────────────────────────────────────── */
+
+.intro {
+  padding: 64px 0;
+  /* Warm peach radial fade near bottom → off-white elsewhere */
+  background: radial-gradient(ellipse 720px 180px at 50% 100%, #ffe0cc 0%, #fbfafc 100%);
+
+  @media (max-width: $breakpoints-md) {
+    padding: 48px 0;
+  }
+}
+
+.intro-inner {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 48px;
+  width: 100%;
+  max-width: $content-max-width;
+  margin: 0 auto;
+
+  @media (max-width: $breakpoints-xl) {
+    flex-direction: column;
+    gap: 24px;
+  }
+}
+
+.intro-title {
+  font-size: 40px;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.5px;
+  color: #160b2b;
+  margin: 0;
+  flex-shrink: 0;
+
+  @media (max-width: $breakpoints-md) {
+    font-size: 32px;
+  }
+}
+
+.intro-description {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  font-size: 18px;
+  font-weight: 400;
+  line-height: 1.5;
+  color: #1a0d33;
+  letter-spacing: -0.25px;
+  max-width: 656px;
+
+  p {
+    margin: 0;
+  }
+
+  @media (max-width: $breakpoints-md) {
+    font-size: 16px;
+  }
+
+  a {
+    font-weight: 700;
+    color: #7235ed;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+/* ─── Main Section ────────────────────────────────────────── */
+
+.main {
+  position: relative;
+  padding: 64px 0 80px;
+  overflow: hidden;
+  /* Purple radial bloom centered on bottom edge + warm-bottom linear tint */
+  background:
+    radial-gradient(50% 13.91% at 50% 100%, #d3bff9 0%, #decffb 23.56%, rgba(222, 207, 251, 0) 100%),
+    linear-gradient(0deg, #e5ebff 19.98%, #fbfafc 100%);
+
+  @media (max-width: $breakpoints-md) {
+    padding: 40px 0 56px;
+  }
+}
+
+.main-bg-moon {
+  position: absolute;
+  left: 50%;
+  bottom: 0;
+  transform: translateX(-50%);
+  width: min(1440px, 100%);
+  height: min(722px, 100%);
+  overflow: hidden;
+  opacity: 0.15;
+  pointer-events: none;
+  z-index: 0;
+
+  svg {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: auto;
+  }
+}
+
+.main-inner {
+  position: relative;
+  z-index: 1;
+  max-width: 800px;
+  margin: 0 auto;
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+/* ─── Content cards ───────────────────────────────────────── */
+
+.card {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: 32px;
+  background: white;
+  border: 1px solid rgba(34, 17, 68, 0.1);
+  border-radius: 16px;
+
+  @media (max-width: $breakpoints-md) {
+    padding: 24px 20px;
+  }
+}
+
+.card-title {
+  font-size: 20px;
+  font-weight: 700;
+  line-height: 1.2;
+  letter-spacing: -0.5px;
+  color: #160b2b;
+  margin: 0;
+}
+
+.card-footnote {
+  font-size: 14px;
+  line-height: 1.5;
+  color: #221144;
+  margin: 0;
+  padding-top: 16px;
+  border-top: 1px solid rgba(34, 17, 68, 0.1);
+}
+
+/* Icon rows in the contact card */
+
+.info-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.info-row {
+  display: flex;
+  gap: 16px;
+}
+
+.info-icon {
+  flex-shrink: 0;
+  color: #7235ed;
+  margin-top: 2px;
+}
+
+.info-body {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #221144;
+
+  p {
+    margin: 0;
+  }
+
+  a {
+    color: #7235ed;
+    font-weight: 700;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+}
+
+.info-label {
+  font-weight: 700;
+  color: #160b2b;
+}
+
+.info-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 2px;
+  align-self: flex-start;
+}
+
+/* Numbered steps in the discount card */
+
+.steps {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  counter-reset: step;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #221144;
+
+  li {
+    counter-increment: step;
+    /* Number is absolutely positioned (not a flex sibling) so the li's
+       inline content flows normally around <strong> etc.
+       Indent = 24px badge + 16px gap, matching the contact card's icon rows. */
+    position: relative;
+    padding-left: 40px;
+
+    &::before {
+      content: counter(step);
+      position: absolute;
+      left: 0;
+      top: 0;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      width: 24px;
+      height: 24px;
+      border-radius: 9999px;
+      background: rgba(114, 53, 237, 0.1);
+      color: #7235ed;
+      font-size: 13px;
+      font-weight: 700;
+    }
+  }
+
+  strong {
+    font-weight: 700;
+    color: #160b2b;
+  }
+}
+
+/* Bullets in the important-notes card */
+
+.notes-list {
+  margin: 0;
+  padding-left: 20px;
+  list-style: disc outside;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  font-size: 16px;
+  line-height: 1.5;
+  color: #221144;
+
+  li::marker {
+    color: #7235ed;
+  }
+
+  strong {
+    font-weight: 700;
+    color: #160b2b;
+  }
+}
+
+/* ─── Callouts ────────────────────────────────────────────── */
+
+/* Inline note: warm peach tint */
+.note-callout {
+  display: flex;
+  gap: 12px;
+  padding: 14px 16px;
+  background: #ffe0cc;
+  border-radius: 12px;
+
+  p {
+    margin: 0;
+    font-size: 15px;
+    line-height: 1.5;
+    color: #1a0d33;
+  }
+}
+
+.note-callout-icon {
+  flex-shrink: 0;
+  color: #ff6600;
+  margin-top: 2px;
+}
+
+/* Standalone legal disclaimer: hairline card */
+.disclaimer {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding: 24px 32px;
+  background: rgba(255, 255, 255, 0.66);
+  border: 1px solid rgba(34, 17, 68, 0.1);
+  border-radius: 16px;
+
+  @media (max-width: $breakpoints-md) {
+    padding: 20px;
+  }
+}
+
+.disclaimer-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: #7235ed;
+}
+
+.disclaimer-label {
+  font-size: 14px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #7235ed;
+  margin: 0;
+}
+
+.disclaimer-text {
+  font-size: 14px;
+  line-height: 1.6;
+  color: #221144;
+  margin: 0;
+}
+
+/* ─── Contact CTA ─────────────────────────────────────────── */
+
+.cta-divider {
+  width: 100%;
+  height: 1px;
+  background: rgba(34, 17, 68, 0.1);
+  margin: 0;
+  border: none;
+}
+
+.cta-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 24px;
+  padding: 32px 80px;
+  background: rgba(255, 255, 255, 0.33);
+  border: 1px solid rgba(255, 255, 255, 0.66);
+  border-radius: 16px;
+  backdrop-filter: blur(6px);
+  box-shadow: 0 2px 4px rgba(34, 17, 68, 0.06), 0 1px 2px rgba(34, 17, 68, 0.08);
+  text-align: center;
+
+  @media (max-width: $breakpoints-md) {
+    padding: 24px;
+  }
+}
+
+.cta-title {
+  font-size: 24px;
+  font-weight: 800;
+  line-height: 1.2;
+  letter-spacing: -0.5px;
+  color: #1a0d33;
+  margin: 0;
+
+  @media (max-width: $breakpoints-md) {
+    font-size: 20px;
+  }
+}
+

--- a/devcon/src/pages/childcare.tsx
+++ b/devcon/src/pages/childcare.tsx
@@ -1,0 +1,195 @@
+import React from 'react'
+import Page from 'components/common/layouts/page'
+import { PageHero } from 'components/common/page-hero'
+import { SEO } from 'components/domain/seo'
+import { MapPin, CarFront, Clock, UserRound, CircleAlert, TriangleAlert, ArrowUpRight } from 'lucide-react'
+import themes from './themes.module.scss'
+import HeroBackground from './past-events-hero.png'
+import MoonBackground from 'assets/images/pages/faq-moon-bg.svg'
+import css from './childcare.module.scss'
+import cn from 'classnames'
+
+const KLAY_WEBSITE = 'https://klay.co.in/foundational-development-program/mumbai/equinox/'
+const KLAY_MAPS = 'https://maps.app.goo.gl/DWE3nzzDEXACjStT9'
+const KLAY_EMAIL = 'shilpa.tlc1361@klay.co.in'
+const KLAY_PHONE = '+91 8591180038'
+
+export default function ChildcarePage() {
+  return (
+    <Page theme={themes['tickets']} withHero darkFooter>
+      <SEO
+        title="Childcare"
+        description="Childcare option for Devcon 8 attendees — KLAY Equinox offers a special discounted rate near the venue in Mumbai."
+      />
+
+      <PageHero
+        className={`${css['hero-no-side-gradient']} !mb-0`}
+        titleClassName={css['hero-title']}
+        heroBackground={HeroBackground}
+        path={[]}
+        title="Childcare"
+      />
+
+      {/* ── Intro band ─────────────────────────────────────── */}
+      <section className={cn(css['intro'], 'section')}>
+        <div className={css['intro-inner']}>
+          <h1 className={css['intro-title']}>
+            Childcare for
+            <br />
+            Devcon Attendees
+          </h1>
+          <div className={css['intro-description']}>
+            <p>
+              To help make Devcon more accessible for attendees traveling with young children, KLAY Equinox is offering
+              a special discounted rate directly to Devcon 8 attendees.
+            </p>
+            <p>
+              KLAY Equinox is an independent childcare provider located approximately 2.4 km from the Devcon 8 venue at
+              Jio World Convention Centre (around 8 minutes by car). Devcon is sharing this option to help families
+              plan their time during the event. For more information, please visit the{' '}
+              <a href={KLAY_WEBSITE} target="_blank" rel="noopener noreferrer">
+                official KLAY Equinox website
+              </a>
+              .
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* ── Main section ───────────────────────────────────── */}
+      <section className={cn(css['main'], 'section')}>
+        <div className={css['main-bg-moon']} aria-hidden="true">
+          <MoonBackground />
+        </div>
+        <div className={css['main-inner']}>
+          {/* Contact information */}
+          <div className={css['card']}>
+            <h2 className={css['card-title']}>KLAY Equinox Centre Contact Information</h2>
+            <div className={css['info-rows']}>
+              <div className={css['info-row']}>
+                <MapPin size={24} strokeWidth={2} className={css['info-icon']} aria-hidden="true" />
+                <div className={css['info-body']}>
+                  <p className={css['info-label']}>Address</p>
+                  <p>Lobby Ground Floor, Tower 4, Equinox Business Park, Kurla West, Mumbai 400070</p>
+                  <a href={KLAY_MAPS} target="_blank" rel="noopener noreferrer" className={css['info-link']}>
+                    Open in Google Maps
+                    <ArrowUpRight size={14} strokeWidth={2} aria-hidden="true" />
+                  </a>
+                </div>
+              </div>
+              <div className={css['info-row']}>
+                <CarFront size={24} strokeWidth={2} className={css['info-icon']} aria-hidden="true" />
+                <div className={css['info-body']}>
+                  <p className={css['info-label']}>Distance from the Devcon venue</p>
+                  <p>Approximately 2.4 km — around 8 minutes by car (traffic dependent).</p>
+                </div>
+              </div>
+              <div className={css['info-row']}>
+                <Clock size={24} strokeWidth={2} className={css['info-icon']} aria-hidden="true" />
+                <div className={css['info-body']}>
+                  <p className={css['info-label']}>Operating hours provided by KLAY</p>
+                  <p>Monday – Friday: 8:30 AM – 7:30 PM</p>
+                  <p>Saturday: 9:00 AM – 2:00 PM (subject to centre operations)</p>
+                </div>
+              </div>
+              <div className={css['info-row']}>
+                <UserRound size={24} strokeWidth={2} className={css['info-icon']} aria-hidden="true" />
+                <div className={css['info-body']}>
+                  <p className={css['info-label']}>Point of contact</p>
+                  <p>
+                    KLAY has assigned a dedicated contact to assist Devcon 8 attendees with enquiries, registration,
+                    availability, and childcare arrangements.
+                  </p>
+                  <p>
+                    Shilpa Waghmare — <a href={`mailto:${KLAY_EMAIL}`}>{KLAY_EMAIL}</a> —{' '}
+                    <a href={`tel:${KLAY_PHONE.replace(/\s/g, '')}`}>{KLAY_PHONE}</a>
+                  </p>
+                </div>
+              </div>
+            </div>
+            <p className={css['card-footnote']}>
+              Attendees should confirm current operating hours, availability, age requirements, and registration
+              conditions directly with KLAY.
+            </p>
+          </div>
+
+          {/* How to access the discount */}
+          <div className={css['card']}>
+            <h2 className={css['card-title']}>How to Access the Devcon Discount</h2>
+            <ol className={css['steps']}>
+              <li>Contact KLAY Equinox directly to enquire about availability.</li>
+              <li>
+                Mention that you are attending <strong>Devcon 8</strong>.
+              </li>
+              <li>Present your valid Devcon ticket during registration to receive the special attendee rate.</li>
+              <li>Complete any registration forms required by KLAY before your child&apos;s first visit.</li>
+            </ol>
+            <div className={css['note-callout']}>
+              <CircleAlert size={18} strokeWidth={2} className={css['note-callout-icon']} aria-hidden="true" />
+              <p>Availability is subject to centre capacity, so early booking is encouraged.</p>
+            </div>
+          </div>
+
+          {/* Important notes */}
+          <div className={css['card']}>
+            <h2 className={css['card-title']}>Important Notes</h2>
+            <ul className={css['notes-list']}>
+              <li>
+                Childcare services are <strong>provided and operated entirely by KLAY</strong>, an independent
+                childcare provider.
+              </li>
+              <li>
+                All enquiries, bookings, registration, admission decisions, payments, refunds, childcare services, and
+                complaints are handled directly by KLAY.
+              </li>
+              <li>
+                Devcon does not guarantee availability or provide transportation, escorts, or supervision between the
+                event venue and the KLAY premises.
+              </li>
+              <li>
+                To better support Devcon families, KLAY Equinox intends to provide a dedicated childcare area for
+                children of Devcon 8 attendees, subject to operational feasibility and centre capacity.
+              </li>
+              <li>
+                Parents and guardians should review KLAY&apos;s terms, policies, eligibility requirements, and
+                operating procedures before booking.
+              </li>
+              <li>
+                Parents and guardians are responsible for deciding whether the KLAY services are appropriate for their
+                child.
+              </li>
+            </ul>
+          </div>
+
+          {/* Disclaimer */}
+          <div className={css['disclaimer']}>
+            <div className={css['disclaimer-header']}>
+              <TriangleAlert size={18} strokeWidth={2} aria-hidden="true" />
+              <p className={css['disclaimer-label']}>Disclaimer</p>
+            </div>
+            <p className={css['disclaimer-text']}>
+              The childcare services are provided independently by KLAY at its own premises. If you choose to use these
+              services, you will contract directly with KLAY, and your use of the services will be subject to
+              KLAY&apos;s terms and conditions, policies, and any applicable law. The Ethereum Foundation assumes no
+              responsibility for the provision of the childcare services by KLAY or for any of their acts or omissions.
+            </p>
+          </div>
+
+          {/* Contact CTA */}
+          <hr className={css['cta-divider']} />
+          <div className={css['cta-card']}>
+            <p className={css['cta-title']}>Ready to arrange childcare?</p>
+            <a
+              href={`mailto:${KLAY_EMAIL}`}
+              className="inline-flex w-full shrink-0 items-center justify-center gap-2 rounded-full bg-[#7235ed] px-8 py-3.5 text-base font-bold text-white transition-[background-color,transform] duration-150 ease-out hover:scale-[1.03] hover:bg-[#5f23d6] active:scale-[0.97] md:w-auto"
+              aria-label="Contact KLAY Equinox by email"
+            >
+              Contact KLAY Equinox
+              <ArrowUpRight size={16} strokeWidth={2} aria-hidden="true" />
+            </a>
+          </div>
+        </div>
+      </section>
+    </Page>
+  )
+}


### PR DESCRIPTION
## Add attendee childcare page
- Adds a new standalone page at `/childcare` presenting the Devcon 8 Attendees Childcare Guide (KLAY Equinox partnership), with content sourced from the Notion guide.
- The page is intentionally not linked from the main navigation — it will be linked from a future FAQ entry.

### Changes
- `src/pages/childcare.tsx` — new page, visually based on /tickets/faq (same hero treatment, intro band, and gradient main section). Static English content in three cards: KLAY centre contact info, how to access the Devcon discount, and important notes.
- `src/pages/childcare.module.scss` — styles adapted from the FAQ page, plus branded callouts: a peach note callout (#FFE0CC bg, CircleAlert icon) for the availability note, and a hairline disclaimer card for the legal text.
- `src/pages/api/sitemap.ts` — added childcare/ to the sitemap routes.