### PR TITLE
fix: update content to use "thousands" instead of "10,000+" 

### DIFF
--- a/devcon/content/en/intl/home.json
+++ b/devcon/content/en/intl/home.json
@@ -81,7 +81,7 @@
     "cards": [
       {
         "title": "Speak at Devcon",
-        "body": "Help to shape the conversation at Devcon and engage 10,000+ builders, researchers, designers, and thinkers from across the decentralized ecosystem.",
+        "body": "Help to shape the conversation at Devcon and engage thousands of builders, researchers, designers, and thinkers from across the decentralized ecosystem.",
         "cta": "Learn more"
       },
       {

--- a/devcon/content/en/intl/speaker_applications.json
+++ b/devcon/content/en/intl/speaker_applications.json
@@ -10,7 +10,7 @@
   },
   "hero": {
     "heading": "Shape the conversation at Devcon",
-    "body": "Programming at Devcon India will engage 10,000+ builders, researchers, designers, and thinkers from across the decentralized ecosystem.",
+    "body": "Programming at Devcon India will engage thousands of builders, researchers, designers, and thinkers from across the decentralized ecosystem.",
     "body_strong": "Got something you want to share? Submit your application.",
     "apply_button": "Apply to speak",
     "guidelines_link": "Read the application guidelines"


### PR DESCRIPTION
## Description

Updates copy from "10,000+ builders" to "thousands of builders" in two places:

- `/speaker-applications` hero intro (`content/en/intl/speaker_applications.json`)
- "Speak at Devcon" card on the home page (`content/en/intl/home.json`)

English content only — Hindi/Marathi translations are regenerated by the translate action on merge.