### PR TITLE
chore: update travel safety information and remove phone number

### DIFF
--- a/devcon/content/en/intl/travel_guide.json
+++ b/devcon/content/en/intl/travel_guide.json
@@ -160,12 +160,12 @@
     "avoid_body": "- Dharavi (at night)\n- Kamathipura\n- Falkland Road\n- Old Mill Compounds in central suburbs\n- Aarey Milk Colony\n- Dimly lit bylanes in any area\n- Isolated spots after 10 PM\n\nLearn more in the [Safety section](#safety)"
   },
   "safety": {
-    "heading": "Safety",
-    "lead": "Generally, major national travel advisories recommend exercising increased or a higher degree of caution in India.",
-    "body_1": "Importantly, Mumbai is not currently identified by any of the advisories cited below as a \"do not travel,\" \"avoid all travel\", or equivalent destination; it instead falls within broader India-wide advice.",
-    "body_2": "Taken together, the advisories state that terrorism remains a risk and that attacks may affect public places, including places visited by tourists and foreign nationals. They note that serious crime against foreign travellers is less frequent, but incidents of violent crime and sexual assault do occur. They also warn that women travellers may experience unwanted attention, harassment or sexual assault; that petty theft, scams and drink spiking occur; and that demonstrations and large gatherings can sometimes become violent or dangerous.",
-    "body_3": "The advisories generally recommend staying aware of your surroundings, taking care of personal belongings and unattended food or drinks, avoiding demonstrations, monitoring local developments, and following instructions from local authorities. Stronger warnings apply to certain specified regions outside Mumbai.",
-    "body_4": "Travelers should check their own government's latest advisory before and during travel, as official guidance can change.",
+    "heading": "Safety in Mumbai",
+    "lead": "The official national travel advisories cited below do not currently advise against travel to Mumbai.",
+    "body_1": "Mumbai falls within their broader guidance for travel in India, while their strongest warnings apply to specified regions elsewhere in the country.",
+    "body_2": "None of the advisories identifies a current Mumbai-specific threat or recommends avoiding the city. At the same time, they continue to identify terrorism as a risk in India generally, including in major cities and busy public places. They also address risks relevant to visitors such as theft and scams, road and transport safety, drink spiking, demonstrations, and harassment or sexual assault affecting women travellers.",
+    "body_3": "The precautions described in the advisories include remaining aware in crowded places, looking after belongings and drinks, taking care at night and when using transport, avoiding demonstrations, monitoring local developments, and following instructions from local authorities.",
+    "body_4": "This section summarises official government guidance rather than providing separate safety advice from Devcon. As official guidance can change, travellers should consult their own government’s current advisory before and during their trip.",
     "advisories_label": "Official national travel advisories:",
     "advisories": [
       "United States",

--- a/devcon/src/pages/childcare.tsx
+++ b/devcon/src/pages/childcare.tsx
@@ -12,7 +12,6 @@ import cn from 'classnames'
 const KLAY_WEBSITE = 'https://klay.co.in/foundational-development-program/mumbai/equinox/'
 const KLAY_MAPS = 'https://maps.app.goo.gl/DWE3nzzDEXACjStT9'
 const KLAY_EMAIL = 'shilpa.tlc1361@klay.co.in'
-const KLAY_PHONE = '+91 8591180038'
 
 export default function ChildcarePage() {
   return (
@@ -101,8 +100,7 @@ export default function ChildcarePage() {
                     availability, and childcare arrangements.
                   </p>
                   <p>
-                    Shilpa Waghmare — <a href={`mailto:${KLAY_EMAIL}`}>{KLAY_EMAIL}</a> —{' '}
-                    <a href={`tel:${KLAY_PHONE.replace(/\s/g, '')}`}>{KLAY_PHONE}</a>
+                    Shilpa Waghmare — <a href={`mailto:${KLAY_EMAIL}`}>{KLAY_EMAIL}</a>
                   </p>
                 </div>
               </div>


### PR DESCRIPTION
## Content tweaks: childcare contact + travel guide Safety copy

**Childcare page** — Removed the KLAY point-of-contact phone number and the now-unused `KLAY_PHONE` const. Email remains the contact channel for attendee enquiries.

**Travel guide → Safety** — Content updated based on Legal's rewrite.

The advisory links, emergency numbers table, and all Safety sub-sections (gender/LGBTQ+, air quality, food, getting around) are unchanged.