### PR TITLE
feat: add promo tag component for travel guide page

### DIFF
--- a/devcon/content/en/intl/travel_guide.json
+++ b/devcon/content/en/intl/travel_guide.json
@@ -113,6 +113,9 @@
     "body": "A 3km trip in Mumbai can take 10 minutes at dawn or 45 minutes at 6pm. Devcon overlaps with **[Diwali](https://www.britannica.com/topic/Diwali-Hindu-festival)**, India's biggest festival, so book your stay early as rooms will go fast.",
     "aside": "We'd generally recommend established hotel chains, though Airbnb and independent hotels work fine too. Unsure about a specific place? Ask in the Devcon [Telegram group](https://t.me/+sitvvHw8D8EzN2Yx).",
     "options_heading": "Accommodation options",
+    "promos": {
+      "flyfi": "Code <strong>{code}</strong> for $50 off"
+    },
     "hotels": [
       {
         "name": "Tripsha",

--- a/devcon/src/components/domain/landing-page/VideoPreview.tsx
+++ b/devcon/src/components/domain/landing-page/VideoPreview.tsx
@@ -35,9 +35,9 @@ export const VideoPreview = () => {
               </p>
 
               {/* Video container — standard YouTube 16:9 aspect */}
-              <div className="relative aspect-video rounded-2xl overflow-hidden border border-[rgba(34,17,68,0.1)] shadow-[0_2px_2px_0_rgba(22,11,43,0.1),0_20px_25px_0_rgba(22,11,43,0.1),0_8px_10px_0_rgba(22,11,43,0.1)]">
+              <div className="relative aspect-video rounded-2xl overflow-hidden bg-black border border-[rgba(34,17,68,0.1)] shadow-[0_2px_2px_0_rgba(22,11,43,0.1),0_20px_25px_0_rgba(22,11,43,0.1),0_8px_10px_0_rgba(22,11,43,0.1)]">
                 {!playing && (
-                  <>
+                  <button type="button" onClick={() => setPlaying(true)} aria-label={t('play_aria')} className="absolute inset-0 w-full h-full cursor-pointer group">
                     <Image
                       src={VideoPoster}
                       alt="Mumbai video preview"
@@ -46,15 +46,10 @@ export const VideoPreview = () => {
                       className="object-cover"
                       priority={false}
                     />
-                    <button
-                      type="button"
-                      onClick={() => setPlaying(true)}
-                      aria-label={t('play_aria')}
-                      className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 size-20 rounded-full bg-[rgba(32,16,63,0.3)] border border-white/20 backdrop-blur-[6px] flex items-center justify-center hover:bg-[rgba(32,16,63,0.5)] transition-[background-color,transform] duration-150 ease-out motion-safe:hover:scale-[1.03] motion-safe:active:scale-[0.97] z-10 cursor-pointer"
-                    >
+                    <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 size-20 rounded-full bg-[rgba(32,16,63,0.3)] border border-white/20 backdrop-blur-[6px] flex items-center justify-center group-hover:bg-[rgba(32,16,63,0.5)] transition-[background-color,transform] duration-150 ease-out motion-safe:group-hover:scale-[1.03] motion-safe:group-active:scale-[0.97] z-10">
                       <Play className="w-8 h-8 text-white fill-white ml-1" />
-                    </button>
-                  </>
+                    </span>
+                  </button>
                 )}
                 {playing && (
                   <iframe

--- a/devcon/src/components/domain/travel-guide/PromoTag.tsx
+++ b/devcon/src/components/domain/travel-guide/PromoTag.tsx
@@ -1,0 +1,25 @@
+import React from 'react'
+import cn from 'classnames'
+
+// Corner-pinned promo badge for the service cards in the Where-to-stay section.
+// Content-agnostic: the caller passes the copy as children, so the same badge
+// works for any accommodation option or future service on the page.
+//
+// The top-right radius matches the card's rounded-2xl so the badge sits flush
+// in the corner. Sizes are in px, not rem-based Tailwind utilities, because the
+// root font-size is 14px at ≤1024 (see travel-guide.module.scss).
+export const PromoTag = ({ children, className }: { children: React.ReactNode; className?: string }) => (
+  <span
+    className={cn(
+      // Deliberately not a flex container: flex turns the runs either side of
+      // the bold code into anonymous items and eats the spaces around it.
+      'absolute top-0 right-0 block max-w-full text-center',
+      'rounded-tr-[16px] rounded-bl-[4px] bg-[#aaeaba] px-[12px] py-[8px]',
+      'text-[12px] leading-[16px] md:text-[14px] md:leading-[20px] text-[#221144]',
+      '[&_strong]:font-bold',
+      className
+    )}
+  >
+    {children}
+  </span>
+)

--- a/devcon/src/components/domain/travel-guide/VideoPlayer.tsx
+++ b/devcon/src/components/domain/travel-guide/VideoPlayer.tsx
@@ -24,21 +24,21 @@ export const VideoPlayer = ({ src, title, poster, posterAlt = '', caption, class
         {playing ? (
           <video src={src} title={title} autoPlay controls playsInline className="h-full aspect-[4/3] object-contain" />
         ) : (
-          <>
+          <button
+            type="button"
+            onClick={() => setPlaying(true)}
+            aria-label={`Play video: ${title}`}
+            className="absolute inset-0 flex items-center justify-center cursor-pointer group"
+          >
             {poster && (
               <div className="relative h-full aspect-[4/3]">
                 <Image src={poster} alt={posterAlt} fill sizes="(max-width: 1080px) 100vw, 660px" className="object-cover" />
               </div>
             )}
-            <button
-              type="button"
-              onClick={() => setPlaying(true)}
-              aria-label={`Play video: ${title}`}
-              className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 size-20 rounded-full bg-[rgba(32,16,63,0.3)] outline outline-1 outline-white/20 backdrop-blur-[6px] flex items-center justify-center hover:bg-[rgba(32,16,63,0.5)] transition-colors z-10 cursor-pointer"
-            >
+            <span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 size-20 rounded-full bg-[rgba(32,16,63,0.3)] outline outline-1 outline-white/20 backdrop-blur-[6px] flex items-center justify-center group-hover:bg-[rgba(32,16,63,0.5)] transition-colors z-10">
               <Play className="w-8 h-8 text-white fill-white ml-1" />
-            </button>
-          </>
+            </span>
+          </button>
         )}
       </div>
       {caption && <div className="pt-[16px] text-[12px] leading-[16px] text-[#594d73]">{caption}</div>}

--- a/devcon/src/pages/travel-guide/index.tsx
+++ b/devcon/src/pages/travel-guide/index.tsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import Image from 'next/image'
+import type { StaticImageData } from 'next/image'
 import Page from 'components/common/layouts/page'
 import { PageHero } from 'components/common/page-hero'
 import { SEO } from 'components/domain/seo'
@@ -13,6 +14,7 @@ import { VideoPlayer } from 'components/domain/travel-guide/VideoPlayer'
 import JaaliBottom from './images/decor/jaali-bottom-border.svg'
 import JaaliSide from './images/decor/jaali-side-border.svg'
 import { Markdown } from 'components/domain/travel-guide/Markdown'
+import { PromoTag } from 'components/domain/travel-guide/PromoTag'
 import { Link } from 'components/common/link'
 import InfiniteScroll from 'lib/components/infinite-scroll/infinite-scroll'
 import {
@@ -87,10 +89,28 @@ const CAROUSEL_IMAGES = [
   CityMarineDrive,
 ]
 
+type HotelMeta = {
+  url: string
+  Logo: React.FC<React.SVGProps<SVGSVGElement>> | null
+  logoImg: StaticImageData | null
+  logoAlt: string
+  /** Renders a PromoTag in the card's top-right corner. `messageKey` points at a
+   *  `stay.promos.*` string taking a `code` param, so the code itself is never
+   *  machine-translated. Keep that copy short — a long string wraps to a second
+   *  line and starts encroaching on the logo. */
+  promo?: { messageKey: string; code: string }
+}
+
 // Zipped positionally with the translated `stay.hotels` array
-const HOTEL_META = [
+const HOTEL_META: HotelMeta[] = [
   { url: 'https://app.tripsha.com/event/69b89b4703d64d0002894a82', Logo: null, logoImg: TripshaLogo, logoAlt: 'Tripsha' },
-  { url: 'https://flyfi.io/promo/devcon2026/', Logo: FlyfiLogo, logoImg: null, logoAlt: 'FLYFI.IO' },
+  {
+    url: 'https://flyfi.io/promo/devcon2026/',
+    Logo: FlyfiLogo,
+    logoImg: null,
+    logoAlt: 'FLYFI.IO',
+    promo: { messageKey: 'stay.promos.flyfi', code: 'DEVCON50' },
+  },
   { url: 'https://www.nirantahotels.com/', Logo: null, logoImg: NirantaLogo, logoAlt: 'Niranta Hotels' },
 ]
 
@@ -182,6 +202,8 @@ const AdvisoryLinks = ({ label, names }: { label: string; names: string[] }) => 
 
 export default function TravelGuidePage() {
   const t = useTranslations('travel_guide')
+
+  const strong = (chunks: React.ReactNode) => <strong>{chunks}</strong>
 
   const navLinks = [
     { title: t('nav.mumbai'), to: '#mumbai' },
@@ -538,7 +560,10 @@ export default function TravelGuidePage() {
         <div className="section gap-y-[48px]">
           <div className="flex flex-col gap-[16px] md:gap-6">
             <h2 className={css['heading-2']}>{t('stay.heading')}</h2>
-            <div className="flex flex-col gap-[12px] md:gap-[48px] lg:flex-row lg:gap-[64px]">
+            {/* No md gap step: while stacked these two columns read as one run of
+                paragraphs, so they keep the 12px paragraph rhythm right up to
+                lg, where the 64px becomes a horizontal column gap */}
+            <div className="flex flex-col gap-[12px] lg:flex-row lg:gap-[64px]">
               <div className="left flex flex-col gap-3 lg:flex-1 lg:min-w-0">
                 <p className={css['lead']}>{t('stay.lead')}</p>
                 <Markdown className={css['prose']}>{t('stay.body')}</Markdown>
@@ -553,18 +578,21 @@ export default function TravelGuidePage() {
               dropdown ladder together */}
           <RevealGroup className="flex flex-col gap-6">
             <h3 className={css['heading-3']}>{t('stay.options_heading')}</h3>
-            <div className="flex flex-col md:flex-row gap-[12px] items-stretch">
+            {/* 3-up only from 1280, where a column is finally wide enough that a
+                promo tag clears the card logo (measured: it still overlaps by
+                ~7px in a 3-up column at 1024) */}
+            <div className="flex flex-col xl:flex-row gap-[12px] items-stretch">
               {(t.raw('stay.hotels') as Array<{ name: string; body: string; cta: string }>)
                 .slice(0, HOTEL_META.length)
                 .map((hotel, i) => {
                   const meta = HOTEL_META[i]
                   return (
-                    <Reveal key={hotel.name} delay={i * 120} className="md:flex-1">
+                    <Reveal key={hotel.name} delay={i * 120} className="xl:flex-1">
                     <a
                       href={meta.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="group h-full flex flex-col justify-between gap-6 rounded-2xl outline outline-1 outline-[rgba(34,17,68,0.1)] bg-[rgba(255,255,255,0.8)] backdrop-blur-[2px] p-[20px] md:p-6 transition-[background-color,box-shadow,transform] duration-150 [transition-timing-function:ease-out] hover:bg-white hover:shadow-md hover:scale-[1.03] active:scale-[0.97]"
+                      className="group relative h-full flex flex-col justify-between gap-6 rounded-2xl outline outline-1 outline-[rgba(34,17,68,0.1)] bg-[rgba(255,255,255,0.8)] backdrop-blur-[2px] p-[20px] md:p-6 transition-[background-color,box-shadow,transform] duration-150 [transition-timing-function:ease-out] hover:bg-white hover:shadow-md hover:scale-[1.03] active:scale-[0.97]"
                     >
                       <div className="flex flex-col gap-6">
                         <div className="h-[32px] flex items-start">
@@ -583,6 +611,9 @@ export default function TravelGuidePage() {
                         {hotel.cta}
                         <ArrowUpRight size={16} />
                       </span>
+                      {meta.promo && (
+                        <PromoTag>{t.rich(meta.promo.messageKey, { strong, code: meta.promo.code })}</PromoTag>
+                      )}
                     </a>
                     </Reveal>
                   )


### PR DESCRIPTION
- Introduces a new promotional feature in the travel guide, allowing the ability to display discount codes for hotels and any future services
- Updates the hotel metadata structure to include promotional information, ensuring accurate representation in the UI
- Fixes a minor body copy spacing issue to improve user reading experience