### PR TITLE
Integrated Indian identity Verification via DigiGo

### DIFF
--- a/devcon/package.json
+++ b/devcon/package.json
@@ -47,6 +47,7 @@
   "dependencies": {
     "@anon-aadhaar/core": "^2.4.3",
     "@anon-aadhaar/react": "^2.4.3",
+    "@digigo/verify": "^0.1.4",
     "@gsap/react": "^2.1.2",
     "@netlify/functions": "^5.3.0",
     "@next/bundle-analyzer": "^14.2.7",

--- a/devcon/src/components/domain/tickets/DigiGoVerificationModal.tsx
+++ b/devcon/src/components/domain/tickets/DigiGoVerificationModal.tsx
@@ -169,7 +169,7 @@ function DigiGoFlow({ onVoucher }: DigiGoFlowProps) {
               </>
             )}
 
-            <div className={css['digigo-card-footer']}>Grievances: grievance@digigo.club</div>
+            <div className={css['digigo-card-footer']}>Grievances: contact@digigo.club</div>
           </div>
         </aside>
       </div>

--- a/devcon/src/components/domain/tickets/DigiGoVerificationModal.tsx
+++ b/devcon/src/components/domain/tickets/DigiGoVerificationModal.tsx
@@ -1,0 +1,271 @@
+import React, { useState } from 'react'
+import { ArrowRight, RotateCw } from 'lucide-react'
+import { useDigiGoVerify, type DigiGoCredential } from '@digigo/verify/react'
+import css from './VerificationModal.module.scss'
+import { pretixEventUrl } from 'config/ticketing'
+
+// Our own route, on our own origin — the one place the DigiGo API key is used.
+const SESSION_ENDPOINT = '/api/tickets/digigo-session/'
+
+type ErrorCode = 'NOT_INDIAN' | 'UNDER_18' | 'NO_VOUCHERS' | 'VERIFICATION_FAILED' | null
+
+const fmt = (s: number) => `${Math.floor(s / 60)}:${String(s % 60).padStart(2, '0')}`
+
+const STEPS = [
+  {
+    title: 'Get the new Aadhaar app',
+    body: (
+      <>
+        Install UIDAI&apos;s <strong>new Aadhaar app</strong> on{' '}
+        <a href="https://apps.apple.com/in/app/aadhaar/id6744029871" target="_blank" rel="noopener noreferrer">
+          iOS
+        </a>{' '}
+        or{' '}
+        <a
+          href="https://play.google.com/store/apps/details?id=in.gov.uidai.pehchaan"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Android
+        </a>
+        . On first launch it sets up your profile with a quick face scan.
+      </>
+    ),
+  },
+  {
+    title: 'Scan the QR',
+    body: (
+      <>
+        Open the app, tap <strong>Scan</strong>, and point it at the code. It expires after a few minutes — regenerate
+        it if it does.
+      </>
+    ),
+  },
+  {
+    title: 'Approve the share',
+    body: (
+      <>
+        Review the details being requested and confirm with <strong>Face Authentication</strong>. Your Aadhaar number is
+        never shown or shared.
+      </>
+    ),
+  },
+  {
+    title: "You're verified",
+    body: <>DigiGo issues a signed credential that says only that you&apos;re Indian — nothing about who you are.</>,
+  },
+]
+
+type DigiGoFlowProps = {
+  onVoucher: (code: string) => void
+}
+
+/**
+ * The QR flow itself. Split out so it mounts exactly when the modal opens: the
+ * hook opens a DigiGo session on mount, and sessions are metered — a component
+ * that renders `null` while closed would still have opened one for every
+ * visitor to the store page.
+ */
+function DigiGoFlow({ onVoucher }: DigiGoFlowProps) {
+  const [error, setError] = useState<string | null>(null)
+  const [errorCode, setErrorCode] = useState<ErrorCode>(null)
+  const [redeeming, setRedeeming] = useState(false)
+
+  const clearError = () => {
+    setError(null)
+    setErrorCode(null)
+  }
+
+  // The credential the browser receives is unverified — the proof goes to our
+  // backend, which verifies it against DigiGo's public JWKS before issuing.
+  const handleResult = async (credential: DigiGoCredential) => {
+    setRedeeming(true)
+    clearError()
+    try {
+      const res = await fetch('/api/tickets/redeem-digigo/', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ proof: credential.proof }),
+      })
+      const data = await res.json()
+      if (data.success && data.voucherCode) {
+        onVoucher(data.voucherCode)
+      } else {
+        setError(data.reason || 'Verification failed. Please try again.')
+        setErrorCode((data.error as ErrorCode) ?? 'VERIFICATION_FAILED')
+      }
+    } catch {
+      setError('Could not reach the verification service. Please try again.')
+      setErrorCode('VERIFICATION_FAILED')
+    } finally {
+      setRedeeming(false)
+    }
+  }
+
+  const { status, qrDataUrl, timeLeft, regenerate } = useDigiGoVerify({
+    sessionEndpoint: SESSION_ENDPOINT,
+    onResult: handleResult,
+  })
+
+  const handleRetry = () => {
+    clearError()
+    regenerate()
+  }
+
+  return (
+    <>
+      <div className={css['digigo-layout']}>
+        <div className={css['digigo-steps-col']}>
+          <p className={css['digigo-kicker']}>How to verify</p>
+          {STEPS.map((step, i) => (
+            <div key={step.title} className={css['digigo-step']} data-n={i + 1}>
+              <h3 className={css['digigo-step-title']}>{step.title}</h3>
+              <p className={css['digigo-step-body']}>{step.body}</p>
+            </div>
+          ))}
+        </div>
+
+        <aside className={css['digigo-qr-col']}>
+          <p className={css['digigo-kicker']}>Scan this</p>
+          <div className={css['digigo-card']}>
+            <div className={css['digigo-card-brand']}>DigiGo Verification</div>
+
+            <div className={css['digigo-qr-box']}>
+              {status === 'verified' ? (
+                <span className={css['digigo-qr-ok']} aria-label="Verified">
+                  ✓
+                </span>
+              ) : status === 'waiting' && qrDataUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={qrDataUrl} alt="Aadhaar verification QR code" className={css['digigo-qr-img']} />
+              ) : status === 'loading' ? (
+                <div className={css['digigo-qr-shimmer']} aria-label="Generating QR code" />
+              ) : (
+                // Only a real timeout says "expired". A session that never
+                // started (missing key, closed event) is unavailability.
+                <span className={css['digigo-qr-dead']}>
+                  {status === 'expired' ? 'QR expired' : 'Verification unavailable'}
+                </span>
+              )}
+            </div>
+
+            {status === 'verified' ? (
+              <p className={css['digigo-card-status--ok']}>{redeeming ? 'Issuing your voucher…' : 'Verified · Indian'}</p>
+            ) : (
+              <>
+                <p className={css['digigo-card-scan']}>Scan with your Aadhaar app to verify</p>
+                <p className={css['digigo-card-status']}>
+                  {status === 'waiting' ? (
+                    <span>Waiting for scan · expires in {fmt(timeLeft)}</span>
+                  ) : status === 'loading' ? (
+                    <span>Preparing QR…</span>
+                  ) : (
+                    <button type="button" className={css['digigo-regen-btn']} onClick={handleRetry}>
+                      <RotateCw size={13} aria-hidden />
+                      Regenerate
+                    </button>
+                  )}
+                </p>
+              </>
+            )}
+
+            <div className={css['digigo-card-footer']}>Grievances: grievance@digigo.club</div>
+          </div>
+        </aside>
+      </div>
+
+      {error && (
+        <div className={css['self-aadhaar-notice']}>
+          {errorCode === 'NO_VOUCHERS' && (
+            <p>
+              <strong className={css['error-title']}>Sorry, the India Resident discount is currently unavailable</strong>
+            </p>
+          )}
+          <p>{error}</p>
+        </div>
+      )}
+      {error && errorCode !== 'NO_VOUCHERS' && (
+        <button type="button" className={css['reset-btn']} onClick={handleRetry}>
+          Try again
+        </button>
+      )}
+    </>
+  )
+}
+
+type DigiGoVerificationModalProps = {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function DigiGoVerificationModal({ isOpen, onClose }: DigiGoVerificationModalProps) {
+  const [voucher, setVoucher] = useState<string | null>(null)
+
+  if (!isOpen) return null
+
+  const handleClose = () => {
+    setVoucher(null)
+    onClose()
+  }
+
+  // Direct link into the Pretix store's voucher redeem flow, which unlocks and
+  // applies the India Resident ticket.
+  const claimUrl = voucher ? pretixEventUrl(`/redeem?voucher=${encodeURIComponent(voucher)}`) : ''
+
+  return (
+    <div
+      className={`${css['overlay']} ${css['self-overlay']}`}
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="digigo-verification-title"
+    >
+      <div className={css['backdrop']} onClick={handleClose} aria-hidden="true" />
+      <div className={`${css['modal']} ${css['self-modal']} ${voucher ? '' : css['digigo-modal']}`}>
+        <button
+          type="button"
+          className={`${css['close']} ${css['self-close']}`}
+          onClick={handleClose}
+          aria-label="Close"
+        >
+          &times;
+        </button>
+
+        {voucher ? (
+          <div className={css['self-padded']}>
+            <h2 id="digigo-verification-title" className={css['success-title']}>
+              You&apos;re verified!
+            </h2>
+            <div className={css['success-text-block']}>
+              <p className={css['success-intro']}>
+                Your DigiGo credential was verified and you&apos;re eligible for the India Resident ticket. Continue to
+                the store to claim it.
+              </p>
+            </div>
+            <a href={claimUrl} className={css['voucher-cta']}>
+              Claim your India Resident ticket
+              <ArrowRight size={20} aria-hidden />
+            </a>
+            <p className={css['privacy']}>No personal data is shared!</p>
+          </div>
+        ) : (
+          <div className={css['self-content']}>
+            <h2 id="digigo-verification-title" className={css['self-title']}>
+              Verification via DigiGo
+            </h2>
+
+            <p className={css['self-intro']}>
+              DigiGo proves your Indian residency using UIDAI&apos;s new Aadhaar app. The ticket store only ever
+              receives a signed result — Indian or not — never your Aadhaar number, name, or photo.
+            </p>
+
+            <hr className={css['self-divider']} aria-hidden="true" />
+
+            <DigiGoFlow onVoucher={setVoucher} />
+
+            <p className={css['self-privacy']}>No personal data is shared!</p>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/devcon/src/components/domain/tickets/DigiGoVerificationModal.tsx
+++ b/devcon/src/components/domain/tickets/DigiGoVerificationModal.tsx
@@ -169,7 +169,7 @@ function DigiGoFlow({ onVoucher }: DigiGoFlowProps) {
               </>
             )}
 
-            <div className={css['digigo-card-footer']}>Grievances: contact@digigo.club</div>
+            <div className={css['digigo-card-footer']}>No personal data is shared!</div>
           </div>
         </aside>
       </div>
@@ -262,7 +262,6 @@ export function DigiGoVerificationModal({ isOpen, onClose }: DigiGoVerificationM
 
             <DigiGoFlow onVoucher={setVoucher} />
 
-            <p className={css['self-privacy']}>No personal data is shared!</p>
           </div>
         )}
       </div>

--- a/devcon/src/components/domain/tickets/VerificationModal.module.scss
+++ b/devcon/src/components/domain/tickets/VerificationModal.module.scss
@@ -857,3 +857,235 @@
     transform: rotate(360deg);
   }
 }
+
+/* ─── DigiGo verification modal ─────────────────────────────────────────────
+ * Two-column placement ported from the DigiGo reference app: numbered steps on
+ * the left, the live QR card on the right. Stacks on narrow screens with the
+ * QR first, so the thing you actually scan isn't buried under the steps.
+ */
+
+.digigo-modal {
+  max-width: 780px;
+}
+
+.digigo-layout {
+  display: grid;
+  grid-template-columns: 1.05fr 0.95fr;
+  gap: 2rem;
+  align-items: start;
+
+  /* Flex, not a one-column grid: the QR card's aspect-ratio box confuses grid
+     row sizing, which lets the two columns overlap once they stack. */
+  @media (max-width: 700px) {
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+  }
+}
+
+.digigo-kicker {
+  font-size: 0.6875rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: #594d73;
+  margin: 0 0 1rem;
+}
+
+.digigo-steps-col {
+  min-width: 0;
+
+  @media (max-width: 700px) {
+    order: 2;
+  }
+}
+
+/* Numbered marker + connector line between steps (DigiGo reference app). */
+.digigo-step {
+  position: relative;
+  padding: 0 0 1.25rem 2.75rem;
+
+  &:last-child {
+    padding-bottom: 0;
+  }
+
+  &::before {
+    content: attr(data-n);
+    position: absolute;
+    left: 0;
+    top: 0;
+    width: 26px;
+    height: 26px;
+    display: grid;
+    place-items: center;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: #fff;
+    background: #160b2b;
+    border-radius: 50%;
+  }
+
+  &:not(:last-child)::after {
+    content: '';
+    position: absolute;
+    left: 12.5px;
+    top: 32px;
+    bottom: 4px;
+    width: 1px;
+    background: #dddae2;
+  }
+}
+
+.digigo-step-title {
+  font-size: 0.9375rem;
+  font-weight: 700;
+  color: #160b2b;
+  line-height: 1.6;
+  margin: 0;
+}
+
+.digigo-step-body {
+  font-size: 0.875rem;
+  color: #1a0d33;
+  line-height: 1.43;
+  margin: 0.25rem 0 0;
+
+  a {
+    color: #7235ed;
+    font-weight: 700;
+    text-decoration: underline;
+
+    &:hover {
+      text-decoration: none;
+    }
+  }
+}
+
+.digigo-qr-col {
+  min-width: 0;
+
+  @media (max-width: 700px) {
+    order: 1;
+  }
+}
+
+.digigo-card {
+  padding: 1.25rem 1rem 1rem;
+  background: #fff;
+  border: 1px solid #dddae2;
+  border-radius: 16px;
+  text-align: center;
+  box-shadow: 0px 2px 4px 0px rgba(22, 11, 43, 0.1), 0px 12px 28px -18px rgba(22, 11, 43, 0.45);
+}
+
+.digigo-card-brand {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #160b2b;
+}
+
+.digigo-qr-box {
+  width: 100%;
+  max-width: 232px;
+  aspect-ratio: 1;
+  margin: 1rem auto 0.75rem;
+  padding: 0.875rem;
+  background: #f6f5f9;
+  border: 1px solid #dddae2;
+  border-radius: 12px;
+  display: grid;
+  place-items: center;
+}
+
+.digigo-qr-img {
+  width: 100%;
+  height: 100%;
+}
+
+.digigo-qr-ok {
+  font-size: 3.5rem;
+  line-height: 1;
+  color: #1f7a45;
+}
+
+.digigo-qr-dead {
+  font-size: 0.8125rem;
+  color: #9b1c1c;
+}
+
+/* Warm skeleton with a band of light sweeping across it while the QR mints. */
+.digigo-qr-shimmer {
+  width: 100%;
+  height: 100%;
+  border-radius: 8px;
+  background: linear-gradient(105deg, #ededf7 38%, #ffffff 50%, #ededf7 62%);
+  background-size: 200% 100%;
+  animation: digigo-qr-shimmer 1.35s ease-in-out infinite;
+}
+
+@keyframes digigo-qr-shimmer {
+  0% {
+    background-position: 200% 0;
+  }
+  100% {
+    background-position: -200% 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .digigo-qr-shimmer {
+    animation: none;
+  }
+}
+
+.digigo-card-scan {
+  font-size: 0.875rem;
+  color: #1a0d33;
+  line-height: 1.43;
+  margin: 0 0 0.25rem;
+}
+
+.digigo-card-status {
+  font-size: 0.75rem;
+  color: #594d73;
+  margin: 0;
+  min-height: 24px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.digigo-card-status--ok {
+  font-size: 0.875rem;
+  font-weight: 700;
+  color: #1f7a45;
+  margin: 0;
+  min-height: 24px;
+}
+
+.digigo-regen-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.375rem;
+  font: inherit;
+  font-size: 0.75rem;
+  color: #1a0d33;
+  background: none;
+  border: 1px solid #dddae2;
+  border-radius: 9999px;
+  padding: 0.25rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.15s;
+
+  &:hover {
+    background: #ededf7;
+  }
+}
+
+.digigo-card-footer {
+  margin-top: 0.875rem;
+  padding-top: 0.625rem;
+  border-top: 1px solid #dddae2;
+  font-size: 0.6875rem;
+  color: #594d73;
+}

--- a/devcon/src/components/domain/tickets/VerificationModal.module.scss
+++ b/devcon/src/components/domain/tickets/VerificationModal.module.scss
@@ -870,7 +870,9 @@
 
 .digigo-layout {
   display: grid;
-  grid-template-columns: 1.05fr 0.95fr;
+  /* Even split — the QR is the thing people came to scan, so it gets as much
+     room as the instructions. */
+  grid-template-columns: 1fr 1fr;
   gap: 2rem;
   align-items: start;
 
@@ -986,10 +988,10 @@
 
 .digigo-qr-box {
   width: 100%;
-  max-width: 232px;
+  max-width: 300px;
   aspect-ratio: 1;
   margin: 1rem auto 0.75rem;
-  padding: 0.875rem;
+  padding: 0.75rem;
   background: #f6f5f9;
   border: 1px solid #dddae2;
   border-radius: 12px;

--- a/devcon/src/config/ticketing.ts
+++ b/devcon/src/config/ticketing.ts
@@ -51,6 +51,16 @@ const ENV_CONFIG = {
       staging: true,
       requireEarlyAccess: false,
     },
+    digigo: {
+      // Second India-resident verification path, alongside Self. DigiGo runs the
+      // Aadhaar face-auth flow and hands back a JWS credential; we verify it
+      // server-side against DigiGo's public JWKS (redeem-digigo.ts) and issue a
+      // voucher from the same pool the Self flow uses.
+      //
+      // There is nothing else to configure: `DIGIGO_API_KEY` (server env only)
+      // selects the event on its own, and @digigo/verify owns the API host.
+      enabled: true,
+    },
     discount: {
       collection: 'test-india-resident',
       // Prefix for community-discount voucher collections (Core Devs, OSS,
@@ -150,6 +160,9 @@ const ENV_CONFIG = {
       // TODO: change to false before tickets go live
       staging: false,
       requireEarlyAccess: false,
+    },
+    digigo: {      
+      enabled: true,
     },
     discount: {
       collection: 'india-resident',

--- a/devcon/src/pages/api/tickets/digigo-session.ts
+++ b/devcon/src/pages/api/tickets/digigo-session.ts
@@ -1,0 +1,44 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { startVerification, DigigoVerifyError } from '@digigo/verify/server'
+import { TICKETING } from 'config/ticketing'
+
+/**
+ * Opens a DigiGo verification session for the browser.
+ *
+ * This is the ONLY place the DigiGo API key is used, and it is server-side: the
+ * browser receives just a short-lived session token, which can drive this one
+ * verification and nothing else. The key selects the event on its own (DigiGo
+ * issues one key per event), so there is nothing else to configure.
+ *
+ * `@digigo/verify/server` ships a ready-made `createSessionRoute`, but it
+ * returns a Web-standard `Request -> Response` handler — devcon is on the Pages
+ * Router, so this calls `startVerification` directly instead.
+ */
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+
+  if (!TICKETING.digigo.enabled) {
+    return res.status(503).json({ error: 'DigiGo verification is not enabled' })
+  }
+
+  const apiKey = process.env.DIGIGO_API_KEY
+  if (!apiKey) {
+    console.error('[digigo-session] DIGIGO_API_KEY is not set')
+    return res.status(503).json({ error: 'could not start verification' })
+  }
+
+  try {
+    const { sessionToken } = await startVerification({ apiKey, ref: req.body?.ref })
+    return res.status(200).json({ sessionToken })
+  } catch (err) {
+    // Never echo the upstream error: key-related detail stays in our logs.
+    // The status still matters to the component — 503 renders "unavailable",
+    // 410 renders "expired".
+    console.error('[digigo-session] startVerification failed:', err)
+    const status = err instanceof DigigoVerifyError ? err.status : 500
+    return res.status(status).json({ error: 'could not start verification' })
+  }
+}

--- a/devcon/src/pages/api/tickets/redeem-digigo.ts
+++ b/devcon/src/pages/api/tickets/redeem-digigo.ts
@@ -1,0 +1,101 @@
+import type { NextApiRequest, NextApiResponse } from 'next'
+import { verifyDigigoCredential } from '@digigo/verify/server'
+import { issueVoucher, DiscountSoldOutError } from '../../../services/discountStore'
+import { TICKETING, discountItemForCollection, discountTypeForCollection } from 'config/ticketing'
+
+/**
+ * DigiGo verification -> India Resident voucher.
+ *
+ * The browser runs the DigiGo QR flow and posts the resulting credential's
+ * `proof` here. `verifyDigigoCredential` checks it against DigiGo's public JWKS
+ * and throws on a bad signature / issuer / expiry, so a successful return is
+ * trustworthy — the client's own `publicSignals` are never read.
+ *
+ * A verified Indian credential issues a voucher from the same pool the Self
+ * flow uses (`TICKETING.discount.collection`), keyed on DigiGo's per-event
+ * nullifier so one Aadhaar identity can only ever claim one voucher.
+ *
+ * Absence is NOT a negative: someone who never produces a credential is
+ * "not established", not "not Indian". Nothing here rejects anyone — it only
+ * ever acts on a credential we actually received and verified.
+ */
+
+function fail(res: NextApiResponse, code: string, reason: string) {
+  return res.status(200).json({ success: false, error: code, reason })
+}
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST'])
+    return res.status(405).end(`Method ${req.method} Not Allowed`)
+  }
+
+  if (!TICKETING.digigo.enabled) {
+    return fail(res, 'DISABLED', 'DigiGo verification is not enabled.')
+  }
+
+  const { proof } = req.body ?? {}
+  if (!proof || typeof proof !== 'string') {
+    return fail(res, 'MISSING_FIELDS', 'Missing proof')
+  }
+
+  let credential: Awaited<ReturnType<typeof verifyDigigoCredential>>
+  try {
+    credential = await verifyDigigoCredential(proof)
+  } catch (err) {
+    console.error('[redeem-digigo] proof verification failed:', err)
+    return fail(res, 'VERIFICATION_FAILED', 'We could not verify this DigiGo credential. Please try again.')
+  }
+
+  if (credential.indian !== 'INDIAN') {
+    return fail(res, 'NOT_INDIAN', 'Sorry, this offer is exclusive to Indian residents with an Aadhaar card.')
+  }
+
+  // 18+ gate, matching the Self flow (which requests `minimumAge: 18` as a
+  // disclosure and rejects when it isn't satisfied). Fails CLOSED: `ageAbove18`
+  // is null when the DigiGo event wasn't configured to request age, and letting
+  // null through would leave this check silently doing nothing. If every
+  // verification starts failing here, the event needs age added to its
+  // requested claims — that is a DigiGo-side config change, not a code one.
+  if (credential.ageAbove18 !== true) {
+    if (credential.ageAbove18 == null) {
+      console.error('[redeem-digigo] credential carried no ageAbove18 — DigiGo event is not requesting age')
+    }
+    return fail(
+      res,
+      'UNDER_18',
+      "Sorry, we can't issue you a code. Your DigiGo credential does not show that you're over 18 years old. Devcon India will have unique, lower cost tickets for Youths aged 5-17 later this year. We recommend waiting until then to purchase a ticket. We apologize for any inconvenience."
+    )
+  }
+
+  if (!credential.nullifier) {
+    return fail(res, 'VERIFICATION_FAILED', 'Could not determine identity nullifier from the credential.')
+  }
+
+  const collection = TICKETING.discount.collection
+  const type = discountTypeForCollection(collection)
+  const itemId = discountItemForCollection(collection)
+  if (!itemId) {
+    return fail(res, 'NO_VOUCHERS', 'This discount is not configured. Please contact support.')
+  }
+
+  // Namespaced so a DigiGo identity never collides with a Self nullifier in the
+  // shared voucher table — and so the issuing path stays auditable.
+  const assignedTo = `digigo:${credential.nullifier}`
+
+  try {
+    // issueVoucher is one-per-identity: a returning nullifier gets the same
+    // code back rather than draining another voucher.
+    const voucher = await issueVoucher(assignedTo, itemId, collection, { type })
+    if (!voucher) {
+      return fail(res, 'NO_VOUCHERS', 'Could not issue a voucher. Please try again later.')
+    }
+    return res.status(200).json({ success: true, voucherCode: voucher.code })
+  } catch (err) {
+    if (err instanceof DiscountSoldOutError) {
+      return fail(res, 'NO_VOUCHERS', 'Sorry, this ticket is sold out.')
+    }
+    console.error('[redeem-digigo] issueVoucher failed:', err)
+    return fail(res, 'NO_VOUCHERS', 'Could not issue a voucher. Please try again later.')
+  }
+}

--- a/devcon/src/pages/tickets/store/index.tsx
+++ b/devcon/src/pages/tickets/store/index.tsx
@@ -7,6 +7,7 @@ import themes from '../../themes.module.scss'
 // import { AnonAadhaarProvider } from '@anon-aadhaar/react'
 // import { VerificationModal } from 'components/domain/tickets/VerificationModal'
 import { SelfVerificationModal } from 'components/domain/tickets/SelfVerificationModal'
+import { DigiGoVerificationModal } from 'components/domain/tickets/DigiGoVerificationModal'
 import { RedeemVoucherModal } from 'components/domain/tickets/RedeemVoucherModal'
 import { Input } from '@/components/ui/input'
 import {
@@ -21,6 +22,7 @@ import {
   Ribbon,
   TicketPercent,
   Loader2,
+  ScanFace,
 } from 'lucide-react'
 import css from './store.module.scss'
 
@@ -228,6 +230,8 @@ function useCountdown() {
 type StoreContentProps = {
   selfVerificationOpen: boolean
   setSelfVerificationOpen: React.Dispatch<React.SetStateAction<boolean>>
+  digigoVerificationOpen: boolean
+  setDigigoVerificationOpen: React.Dispatch<React.SetStateAction<boolean>>
   useSelfStaging: boolean
   setUseSelfStaging: (value: boolean) => void
   initialTickets: TicketInfo[]
@@ -236,6 +240,8 @@ type StoreContentProps = {
 function StoreContent({
   selfVerificationOpen,
   setSelfVerificationOpen,
+  digigoVerificationOpen,
+  setDigigoVerificationOpen,
   useSelfStaging,
   setUseSelfStaging,
   initialTickets,
@@ -659,21 +665,36 @@ function StoreContent({
                       prove Indian residency.
                     </p>
                   </div>
-                  <div className={css['application-card-footer']}>
+                  <div className={`${css['application-card-footer']} ${css['application-card-footer--wrap']}`}>
                     <CardPrice combined="$149" />
                     {!launched ? (
                       <span className={css['opens-label']}>Opens July</span>
                     ) : discountSoldOut('india-resident') ? (
                       <span className={css['sold-out-badge']}>Sold out</span>
                     ) : (
-                      <button
-                        type="button"
-                        className={css['verify-self-btn']}
-                        onClick={() => setSelfVerificationOpen(true)}
-                      >
-                        <SelfLogo className={css['self-logo']} aria-hidden="true" />
-                        Verify via Self
-                      </button>
+                      // Two independent proofs of Indian residency, same voucher
+                      // pool: Self (Aadhaar ZK proof) and DigiGo (Aadhaar app
+                      // face-auth). Either one unlocks the ticket.
+                      <div className={css['verify-btn-group']}>
+                        {TICKETING.digigo.enabled && (
+                          <button
+                            type="button"
+                            className={css['verify-self-btn']}
+                            onClick={() => setDigigoVerificationOpen(true)}
+                          >
+                            <ScanFace size={16} strokeWidth={2} aria-hidden="true" />
+                            Verify via DigiGo
+                          </button>
+                        )}
+                        <button
+                          type="button"
+                          className={css['verify-self-btn']}
+                          onClick={() => setSelfVerificationOpen(true)}
+                        >
+                          <SelfLogo className={css['self-logo']} aria-hidden="true" />
+                          Verify via Self
+                        </button>
+                      </div>
                     )}
                   </div>
                 </div>
@@ -778,6 +799,8 @@ function StoreContent({
         email={earlyAccessEmail ?? undefined}
       />
 
+      <DigiGoVerificationModal isOpen={digigoVerificationOpen} onClose={() => setDigigoVerificationOpen(false)} />
+
       <RedeemVoucherModal isOpen={redeemOpen} onClose={() => setRedeemOpen(false)} />
 
       <VerifyDiscountModal isOpen={verifyDiscountOpen} onClose={() => setVerifyDiscountOpen(false)} />
@@ -787,6 +810,7 @@ function StoreContent({
 
 export default function TicketsStorePage({ initialTickets = [] }: { initialTickets?: TicketInfo[] }) {
   const [selfVerificationOpen, setSelfVerificationOpen] = useState(false)
+  const [digigoVerificationOpen, setDigigoVerificationOpen] = useState(false)
   const [useSelfStaging, setUseSelfStaging] = useState(TICKETING.self.staging)
 
   return (
@@ -796,6 +820,8 @@ export default function TicketsStorePage({ initialTickets = [] }: { initialTicke
           <StoreContent
             selfVerificationOpen={selfVerificationOpen}
             setSelfVerificationOpen={setSelfVerificationOpen}
+            digigoVerificationOpen={digigoVerificationOpen}
+            setDigigoVerificationOpen={setDigigoVerificationOpen}
             useSelfStaging={useSelfStaging}
             setUseSelfStaging={setUseSelfStaging}
             initialTickets={initialTickets}

--- a/devcon/src/pages/tickets/store/store.module.scss
+++ b/devcon/src/pages/tickets/store/store.module.scss
@@ -998,6 +998,32 @@
   gap: 0.5rem;
 }
 
+/* For footers carrying more than one action (India Resident: Self + DigiGo) —
+   the buttons drop below the price instead of squeezing it. */
+.application-card-footer--wrap {
+  flex-wrap: wrap;
+  row-gap: 0.75rem;
+}
+
+.verify-btn-group {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-left: auto;
+
+  /* The lone-button case pushes itself right with margin-left:auto; inside the
+     group the group does that, so reset it or the buttons split apart. On a
+     card too narrow for both, `flex: 1` makes them stack as equal full-width
+     rows instead of two ragged right-aligned pills. */
+  .verify-self-btn {
+    margin-left: 0;
+    flex: 1 1 auto;
+    justify-content: center;
+  }
+}
+
 .application-price {
   font-size: 1.25rem;
   font-weight: 700;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,7 +45,7 @@ importers:
         version: link:../lib
       next:
         specifier: 15.3.6
-        version: 15.3.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0)
+        version: 15.3.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0)
       react:
         specifier: 19.2.3
         version: 19.2.3
@@ -177,6 +177,9 @@ importers:
       '@anon-aadhaar/react':
         specifier: ^2.4.3
         version: 2.4.3(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10)
+      '@digigo/verify':
+        specifier: ^0.1.4
+        version: 0.1.4(react@19.2.3)
       '@gsap/react':
         specifier: ^2.1.2
         version: 2.1.2(gsap@3.13.0)(react@19.2.3)
@@ -1694,7 +1697,7 @@ importers:
         version: 9.32.0(jiti@2.5.1)
       eslint-config-next:
         specifier: 16.0.7
-        version: 16.0.7(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
+        version: 16.0.7(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
       fastbench:
         specifier: ^1.0.1
         version: 1.0.1
@@ -1821,7 +1824,7 @@ importers:
         version: 5.3.0
       '@serwist/next':
         specifier: ^9.5.11
-        version: 9.5.11(next@16.1.1(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0))(react@19.2.3)(typescript@5.9.3)(webpack@5.100.2(@swc/core@1.13.5))
+        version: 9.5.11(next@16.1.1(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0))(react@19.2.3)(typescript@5.9.3)(webpack@5.100.2(@swc/core@1.13.5))
       '@supabase/ssr':
         specifier: ^0.7.0
         version: 0.7.0(@supabase/supabase-js@2.106.2)
@@ -1845,7 +1848,7 @@ importers:
         version: 1.17.0(react@19.2.3)
       next:
         specifier: 16.1.1
-        version: 16.1.1(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0)
+        version: 16.1.1(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0)
       panzoom:
         specifier: ^9.4.3
         version: 9.4.3
@@ -1912,7 +1915,7 @@ importers:
         version: 9.32.0(jiti@2.5.1)
       eslint-config-next:
         specifier: 16.0.7
-        version: 16.0.7(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+        version: 16.0.7(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
       serwist:
         specifier: ^9.5.11
         version: 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
@@ -3312,6 +3315,14 @@ packages:
   '@datastax/astra-db-ts@1.5.0':
     resolution: {integrity: sha512-Z9pEVyyHfglh8XAKrIASxdvORdei4pLUKDDGarqYvBkA9B9rKdqqdN+4I42Dz8paU5uscu8FwM5mc+Ly/U6jfA==}
     engines: {node: '>=14.0.0'}
+
+  '@digigo/verify@0.1.4':
+    resolution: {integrity: sha512-fVuk56tSyB52hY4+NySONmm+8zeRzjy8nL+Kk0hIV2r+9SeyeXpA3OG3+FBTmH5Ff4np5KBF/0xfeaFXtfl5Lg==}
+    peerDependencies:
+      react: 19.2.3
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   '@discoveryjs/json-ext@0.5.7':
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
@@ -6554,7 +6565,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'The package is now available as "qr": npm install qr'
+    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
 
   '@pcd/gpc@0.4.1':
     resolution: {integrity: sha512-ltdoAe3+umiKoqVoiLL2lAvXD9svbVXkCczv9qDg6qd9M9GUzzSKDImeBfDUZHhotekg8g5acOCDbREBrqZg6A==}
@@ -13208,10 +13219,12 @@ packages:
   conventional-changelog-atom@2.0.8:
     resolution: {integrity: sha512-xo6v46icsFTK3bb7dY/8m2qvc8sZemRgdqLb/bjpBsH2UyOS8rKNTgcb5025Hri6IpANPApbXMg15QLb1LJpBw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-codemirror@2.0.8:
     resolution: {integrity: sha512-z5DAsn3uj1Vfp7po3gpt2Boc+Bdwmw2++ZHa5Ak9k0UKsYAO5mH1UBTN0qSCuJZREIhX6WU4E1p3IW2oRCNzQw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-conventionalcommits@4.6.3:
     resolution: {integrity: sha512-LTTQV4fwOM4oLPad317V/QNQ1FY4Hju5qeBIM1uTHbrnCE+Eg4CdRZ3gO2pUeR+tzWdp80M2j3qFFEDWVqOV4g==}
@@ -13220,26 +13233,32 @@ packages:
   conventional-changelog-core@4.2.4:
     resolution: {integrity: sha512-gDVS+zVJHE2v4SLc6B0sLsPiloR0ygU7HaDW14aNJE1v4SlqJPILPl/aJC7YdtRE4CybBf8gDwObBvKha8Xlyg==}
     engines: {node: '>=10'}
+    deprecated: Deprecated and no longer maintained. Please use conventional-changelog instead.
 
   conventional-changelog-ember@2.0.9:
     resolution: {integrity: sha512-ulzIReoZEvZCBDhcNYfDIsLTHzYHc7awh+eI44ZtV5cx6LVxLlVtEmcO+2/kGIHGtw+qVabJYjdI5cJOQgXh1A==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-eslint@3.0.9:
     resolution: {integrity: sha512-6NpUCMgU8qmWmyAMSZO5NrRd7rTgErjrm4VASam2u5jrZS0n38V7Y9CzTtLT2qwz5xEChDR4BduoWIr8TfwvXA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-express@2.0.6:
     resolution: {integrity: sha512-SDez2f3iVJw6V563O3pRtNwXtQaSmEfTCaTBPCqn0oG0mfkq0rX4hHBq5P7De2MncoRixrALj3u3oQsNK+Q0pQ==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jquery@3.0.11:
     resolution: {integrity: sha512-x8AWz5/Td55F7+o/9LQ6cQIPwrCjfJQ5Zmfqi8thwUEKHstEn4kTIofXub7plf1xvFA2TqhZlq7fy5OmV6BOMw==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-jshint@2.0.9:
     resolution: {integrity: sha512-wMLdaIzq6TNnMHMy31hql02OEQ8nCQfExw1SE0hYL5KvU+JCTuPaDO+7JiogGT2gJAxiUGATdtYYfh+nT+6riA==}
     engines: {node: '>=10'}
+    deprecated: This preset is deprecated. Please use conventional-changelog-conventionalcommits or conventional-changelog-angular instead.
 
   conventional-changelog-preset-loader@2.3.4:
     resolution: {integrity: sha512-GEKRWkrSAZeTq5+YjUZOYxdHq+ci4dNwHvpaBC3+ENalzFWuCWa9EZXSuZBpkr72sMdKB+1fyDV4takK1Lf58g==}
@@ -13433,6 +13452,7 @@ packages:
 
   crypto-js@4.2.0:
     resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+    deprecated: Active development of CryptoJS has been discontinued. This library is no longer maintained.
 
   crypto-random-string@2.0.0:
     resolution: {integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==}
@@ -15490,7 +15510,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -15500,7 +15520,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
+    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -16893,6 +16913,9 @@ packages:
   jose@6.1.3:
     resolution: {integrity: sha512-0TpaTfihd4QMNwrz/ob2Bp7X04yuxJkjRGi4aKmOqwhov54i6u79oCv7T+C7lo70MKH6BesI3vscD1yb/yzKXQ==}
 
+  jose@6.2.9:
+    resolution: {integrity: sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==}
+
   jotai-optics@0.4.0:
     resolution: {integrity: sha512-osbEt9AgS55hC4YTZDew2urXKZkaiLmLqkTS/wfW5/l0ib8bmmQ7kBXSFaosV6jDDWSp00IipITcJARFHdp42g==}
     peerDependencies:
@@ -17170,6 +17193,7 @@ packages:
 
   jsrsasign@11.1.0:
     resolution: {integrity: sha512-Ov74K9GihaK9/9WncTe1mPmvrO7Py665TUfUKvraXBpu+xcTWitrtuOwcjf4KMU9maPaYn0OuaWy0HOzy/GBXg==}
+    deprecated: This package is no longer maintained.
 
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
@@ -27306,6 +27330,12 @@ snapshots:
       typed-emitter: 2.1.0
       uuidv7: 0.6.3
 
+  '@digigo/verify@0.1.4(react@19.2.3)':
+    dependencies:
+      jose: 6.2.9
+    optionalDependencies:
+      react: 19.2.3
+
   '@discoveryjs/json-ext@0.5.7': {}
 
   '@dotenvx/dotenvx@1.51.1':
@@ -32684,7 +32714,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.82.5
       semver: 7.8.1
     transitivePeerDependencies:
@@ -36652,7 +36682,7 @@ snapshots:
     transitivePeerDependencies:
       - browserslist
 
-  '@serwist/next@9.5.11(next@16.1.1(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0))(react@19.2.3)(typescript@5.9.3)(webpack@5.100.2(@swc/core@1.13.5))':
+  '@serwist/next@9.5.11(next@16.1.1(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0))(react@19.2.3)(typescript@5.9.3)(webpack@5.100.2(@swc/core@1.13.5))':
     dependencies:
       '@serwist/build': 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
       '@serwist/utils': 9.5.11(browserslist@4.28.2)
@@ -36661,7 +36691,7 @@ snapshots:
       browserslist: 4.28.2
       glob: 13.0.6
       kolorist: 1.8.0
-      next: 16.1.1(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0)
+      next: 16.1.1(@babel/core@7.28.4)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0)
       react: 19.2.3
       semver: 7.7.4
       serwist: 9.5.11(browserslist@4.28.2)(typescript@5.9.3)
@@ -50844,7 +50874,7 @@ snapshots:
       eslint: 8.8.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.8.0)
       eslint-plugin-react: 7.37.5(eslint@8.8.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.8.0)
@@ -50882,7 +50912,7 @@ snapshots:
       eslint: 8.8.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.8.0)
       eslint-plugin-react: 7.37.5(eslint@8.8.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.8.0)
@@ -50901,7 +50931,7 @@ snapshots:
       eslint: 8.8.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.8.0)
       eslint-plugin-react: 7.37.5(eslint@8.8.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.8.0)
@@ -50912,33 +50942,13 @@ snapshots:
       - eslint-plugin-import-x
       - supports-color
 
-  eslint-config-next@16.0.7(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3):
+  eslint-config-next@16.0.7(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 16.0.7
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
-      eslint-plugin-jsx-a11y: 6.10.2(eslint@9.32.0(jiti@2.5.1))
-      eslint-plugin-react: 7.37.5(eslint@9.32.0(jiti@2.5.1))
-      eslint-plugin-react-hooks: 7.0.0(eslint@9.32.0(jiti@2.5.1))
-      globals: 16.4.0
-      typescript-eslint: 8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
-    optionalDependencies:
-      typescript: 5.9.3
-    transitivePeerDependencies:
-      - '@typescript-eslint/parser'
-      - eslint-import-resolver-webpack
-      - eslint-plugin-import-x
-      - supports-color
-
-  eslint-config-next@16.0.7(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3):
-    dependencies:
-      '@next/eslint-plugin-next': 16.0.7
-      eslint: 9.32.0(jiti@2.5.1)
-      eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-react: 7.37.5(eslint@9.32.0(jiti@2.5.1))
       eslint-plugin-react-hooks: 7.0.0(eslint@9.32.0(jiti@2.5.1))
@@ -50988,7 +50998,7 @@ snapshots:
     dependencies:
       debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.8.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.8.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.10
@@ -51031,7 +51041,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -51061,7 +51071,7 @@ snapshots:
       tinyglobby: 0.2.14
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
     transitivePeerDependencies:
       - supports-color
 
@@ -51109,11 +51119,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       debug: 3.2.7(supports-color@5.5.0)
     optionalDependencies:
-      '@typescript-eslint/parser': 8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.32.0(jiti@2.5.1))
@@ -51188,7 +51198,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -51217,7 +51227,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -51246,7 +51256,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -51275,7 +51285,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -51286,7 +51296,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -51298,7 +51308,7 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3)
+      '@typescript-eslint/parser': 8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -51315,7 +51325,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.32.0(jiti@2.5.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.48.1(eslint@9.32.0(jiti@2.5.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.32.0(jiti@2.5.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -54820,6 +54830,8 @@ snapshots:
 
   jose@6.1.3: {}
 
+  jose@6.2.9: {}
+
   jotai-optics@0.4.0(jotai@2.8.4(@types/react@19.1.8)(react@19.2.3))(optics-ts@2.4.1):
     dependencies:
       jotai: 2.8.4(@types/react@19.1.8)(react@19.2.3)
@@ -56146,6 +56158,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      cosmiconfig: 5.2.1
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-cache: 0.82.5
+      metro-core: 0.82.5
+      metro-runtime: 0.82.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.82.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       connect: 3.7.0
@@ -56160,6 +56187,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-core@0.82.5:
     dependencies:
@@ -56271,6 +56299,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
@@ -56298,7 +56327,7 @@ snapshots:
       metro-babel-transformer: 0.82.5
       metro-cache: 0.82.5
       metro-cache-key: 0.82.5
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.82.5
       metro-file-map: 0.82.5
       metro-resolver: 0.82.5
@@ -56365,6 +56394,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   micro-ftch@0.3.1: {}
 
@@ -57399,7 +57429,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@15.3.6(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0):
+  next@15.3.6(@babel/core@7.28.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)(sass@1.44.0):
     dependencies:
       '@next/env': 15.3.6
       '@swc/counter': 0.1.3
@@ -57409,7 +57439,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 15.3.5
       '@next/swc-darwin-x64': 15.3.5
@@ -57459,7 +57489,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.3
       react-dom: 19.2.3(react@19.2.3)
-      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.3)
+      styled-jsx: 5.1.6(@babel/core@7.28.0)(react@19.2.3)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.0.7
       '@next/swc-darwin-x64': 16.0.7


### PR DESCRIPTION
## What

Adds **Verify via DigiGo** next to **Verify via Self** on the India Resident card. Second door to the same voucher pool — the Self flow is untouched.

DigiGo runs UIDAI's Aadhaar app flow (QR + face auth) and returns a signed credential asserting only *Indian / not Indian*. No Aadhaar number, name, DOB or photo reaches Devcon.

Built on [`@digigo/verify`](https://www.npmjs.com/package/@digigo/verify).

## How

Modal opens a session via `/api/tickets/digigo-session` — the only place `DIGIGO_API_KEY` is used, server-side. Attendee scans the QR; the credential's `proof` goes to `/api/tickets/redeem-digigo`, which verifies it against DigiGo's public JWKS (the client's `publicSignals` are never read). Indian + 18+ → voucher → Pretix redeem link.

Both routes call the SDK directly rather than using its drop-in handlers, which are Web-standard `Request → Response` and don't fit Pages Router.

## Screenshots
1) Verify via DigiGo CTA
<img width="1459" height="783" alt="Screenshot 2026-08-16 at 7 01 01 PM" src="https://github.com/user-attachments/assets/8d03069b-3775-4b82-ab5c-1c2be13080b9" />

2) QR Modal Open
<img width="1412" height="784" alt="Screenshot 2026-08-16 at 7 01 10 PM" src="https://github.com/user-attachments/assets/ea4c672c-e96c-4e18-a35f-d4a4d70e26f0" />

3) Indian Identity successfully verified
<img width="1433" height="780" alt="Screenshot 2026-08-16 at 7 03 44 PM" src="https://github.com/user-attachments/assets/b23eb2b4-5117-44dc-bad7-09b824d8fffb" />


## PoC Video Link
https://drive.google.com/file/d/1kQ32RERyYChLw4lDl23xs5HwgVrwa1fu/view?usp=drive_link

## Notes for review

- The QR flow is split into an inner component so it mounts only when the modal opens — sessions are metered, and an always-mounted hook would open one per store visitor.
- Vouchers are keyed `digigo:<nullifier>` (a per-event pseudonym, not an identity) — one claim per Aadhaar identity.
- The 18+ gate fails **closed** (`ageAbove18 !== true`), matching Self. A null age would otherwise leave the check silently doing nothing.
- Styles are additive; the footer-wrap modifier applies only to this one card.

## Before launch

- [ ] Set `DIGIGO_API_KEY` in Netlify. Until then the card shows "Verification unavailable".
- [ ] Cross-provider dedup: Self and DigiGo nullifiers can't be linked, so one person can claim through both. Needs a shared key (email, or a Pretix limit) if that matters.

## Testing

`tsc --noEmit` clean. Modal verified against live DigiGo: session opened, QR rendered, countdown running; two columns on desktop, QR above steps on mobile. Redeem route rejects missing/tampered credentials. Voucher issuance not exercised end to end — needs a real Aadhaar scan against a configured key.
