### PR TITLE
Fix timezone bug & correct 'clear filters' tap target size

### DIFF
--- a/.claude/skills/time-and-mock-now/SKILL.md
+++ b/.claude/skills/time-and-mock-now/SKILL.md
@@ -62,7 +62,12 @@ Append to any URL — **all values are interpreted as UTC**:
 ```
 
 `mockSpeed` accelerates the clock (1 = real-time). From `mockNow`, time advances
-at real speed × `mockSpeed`.
+at real speed × `mockSpeed`. When a mock is active, the hook's tick interval is
+divided by the speed (floored at 250ms), so consumers refresh per *mocked*
+interval — a `useNow(60_000)` caller at ×60 re-renders every real second. All
+hook instances share one clock anchor per (mockNow, mockSpeed), so client-side
+navigation never rewinds the mock clock; a full page reload restarts it at
+`mockNow` (matching the debug panel's "Apply & reload").
 
 Note: the debug panel's Mock-now field is different — it takes **venue
 wall-clock time** (the selected dataset's timezone, matching what the schedule

--- a/.claude/skills/time-and-mock-now/SKILL.md
+++ b/.claude/skills/time-and-mock-now/SKILL.md
@@ -64,6 +64,11 @@ Append to any URL — **all values are interpreted as UTC**:
 `mockSpeed` accelerates the clock (1 = real-time). From `mockNow`, time advances
 at real speed × `mockSpeed`.
 
+Note: the debug panel's Mock-now field is different — it takes **venue
+wall-clock time** (the selected dataset's timezone, matching what the schedule
+displays) and converts to a UTC instant when writing `?mockNow=`. Only raw URL
+values follow the interpreted-as-UTC rules above.
+
 ## Gotchas
 
 - `useNow()` returns `null` during SSR / first paint (avoids hydration

--- a/event-app/CLAUDE.md
+++ b/event-app/CLAUDE.md
@@ -15,6 +15,7 @@ pnpm lint
 - **Offline-first data**: all persisted state goes through the Dexie/IndexedDB-backed SWR layer, never ad-hoc fetch + useState for API data. `/api/*` stays `NetworkOnly` in the service worker; API caching is owned by the SWR/Dexie layer, not the SW.
 - **Service worker**: precache stays limited to the app-shell routes. Never enable `skipWaiting`; updates are opt-in via the update toast (`ServiceWorkerUpdater.tsx`).
 - **Current time**: never call `Date.now()` / `new Date()` directly in components. Use the shared `useNow`/`useNowMs` hooks (`src/hooks/useNow.ts`) so time can be mocked with `?mockNow=` / `?mockSpeed=` query params. For content dated against the real world rather than event time (announcements), use `useRealWorldNowMs` — it opts out of the per-deployment event-start auto-mock, which would otherwise let the selected dataset (e.g. devcon-7 → Nov 2024) decide whether today's announcements are visible.
+- **Event timezone**: the API serves session times as plain UTC instants with no timezone; all wall-clock rendering and day grouping must go through the venue-timezone helpers in `src/data/eventTime.ts` (`eventFmt`, `eventDayKey`, …). Never format session times with a bare `Intl.DateTimeFormat` or local `Date` getters — that shifts the schedule with the viewer's system timezone. Announcements are the exception (real-world-dated, intentionally viewer-local).
 - **Code style**: double quotes, semicolons (unlike the devcon package).
 
 ## Announcements & highlights

--- a/event-app/src/components/DebugPanel.tsx
+++ b/event-app/src/components/DebugPanel.tsx
@@ -10,6 +10,7 @@ import {
   type DatasetKey,
 } from "@/data/dataset";
 import { utcMsToWallClock, wallClockToUtcMs } from "@/data/eventTime";
+import { useNowMs } from "@/hooks/useNow";
 
 /**
  * Dev-only debug panel: mock the current time (`mockNow`/`mockSpeed`) and swap
@@ -21,6 +22,32 @@ import { utcMsToWallClock, wallClockToUtcMs } from "@/data/eventTime";
  * timezone), matching what the schedule displays; the `?mockNow=` URL param it
  * writes remains a plain UTC instant.
  */
+/**
+ * Live readout of the effective "now" (venue wall-clock). Reads the same
+ * shared clock as the schedule (useNow), so it shows exactly what the
+ * live/upcoming logic sees — including `?mockNow=` / `?mockSpeed=`. A child
+ * component so the ticking hook only runs where it's rendered.
+ */
+function DebugClock({ tz, speed }: { tz: string; speed: number }) {
+  const nowMs = useNowMs(1000);
+  const wall = utcMsToWallClock(tz, nowMs, true);
+  const [date, time] = wall.split("T");
+  // DD/MM/YYYY, matching how the Mock-now datetime-local field displays.
+  const [y, m, d] = date.split("-");
+  return (
+    <span className="tabular-nums">
+      {d}/{m}/{y} {time}
+      {speed !== 1 && <span className="ml-1 font-semibold">×{speed}</span>}
+    </span>
+  );
+}
+
+// Effective mock speed with useNow's clamp rule (NaN / <=0 → 1).
+function parseSpeed(raw: string | null): number {
+  const n = raw ? parseFloat(raw) : NaN;
+  return isNaN(n) || n <= 0 ? 1 : n;
+}
+
 export function DebugPanel() {
   const params =
     typeof window !== "undefined"
@@ -60,6 +87,11 @@ export function DebugPanel() {
   };
 
   if (!enabled) return null;
+
+  // Clock timezone comes from the URL-active dataset (what the schedule
+  // renders), not the panel's unsaved selection.
+  const activeTz = DATASETS[getActiveDatasetKey()].timezone;
+  const effectiveSpeed = parseSpeed(params.get("mockSpeed"));
 
   const apply = () => {
     const p = new URLSearchParams(window.location.search);
@@ -101,6 +133,13 @@ export function DebugPanel() {
       {open && (
         <div className="fixed top-[124px] right-4 z-[100] w-72 rounded-2xl border border-[#E1E4EA] bg-white p-4 text-sm shadow-2xl">
           <p className="mb-3 font-bold">Debug</p>
+
+          <div className="mb-3 text-xs text-gray-500">
+            <p>Now ({activeTz}):</p>
+            <p>
+              <DebugClock tz={activeTz} speed={effectiveSpeed} />
+            </p>
+          </div>
 
           <label className="mb-1 block text-xs font-medium text-gray-500">
             Mock now (venue time · {DATASETS[dataset].timezone})

--- a/event-app/src/components/DebugPanel.tsx
+++ b/event-app/src/components/DebugPanel.tsx
@@ -9,20 +9,17 @@ import {
   getActiveDatasetKey,
   type DatasetKey,
 } from "@/data/dataset";
-
-/** local Date → "YYYY-MM-DDTHH:mm" for a datetime-local input. */
-function toInputValue(d: Date): string {
-  const pad = (n: number) => String(n).padStart(2, "0");
-  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(
-    d.getHours()
-  )}:${pad(d.getMinutes())}`;
-}
+import { utcMsToWallClock, wallClockToUtcMs } from "@/data/eventTime";
 
 /**
  * Dev-only debug panel: mock the current time (`mockNow`/`mockSpeed`) and swap
  * the event dataset (test-devcon-8 / devcon8 / Devcon 7). Applying writes the URL query params
  * and reloads, so the time hook and data provider pick them up. Visible in
  * development, when `?debug` is present, or when NEXT_PUBLIC_ENABLE_DEBUG=true.
+ *
+ * The Mock-now field is venue wall-clock time (the selected dataset's
+ * timezone), matching what the schedule displays; the `?mockNow=` URL param it
+ * writes remains a plain UTC instant.
  */
 export function DebugPanel() {
   const params =
@@ -42,8 +39,9 @@ export function DebugPanel() {
   const [mockNow, setMockNow] = useState(() => {
     const raw = params.get("mockNow");
     if (!raw) return "";
-    const d = new Date(raw);
-    return isNaN(d.getTime()) ? "" : toInputValue(d);
+    const t = new Date(raw).getTime();
+    if (isNaN(t)) return "";
+    return utcMsToWallClock(DATASETS[getActiveDatasetKey()].timezone, t);
   });
   const [mockSpeed, setMockSpeed] = useState(() => params.get("mockSpeed") ?? "");
   const [dataset, setDataset] = useState<DatasetKey>(() =>
@@ -56,14 +54,23 @@ export function DebugPanel() {
   const handleDatasetChange = (key: DatasetKey) => {
     setDataset(key);
     const start = DATASETS[key]?.startDate;
-    if (start) setMockNow(toInputValue(new Date(start)));
+    if (start) {
+      setMockNow(utcMsToWallClock(DATASETS[key].timezone, Date.parse(start)));
+    }
   };
 
   if (!enabled) return null;
 
   const apply = () => {
     const p = new URLSearchParams(window.location.search);
-    if (mockNow) p.set("mockNow", new Date(mockNow).toISOString());
+    if (mockNow) {
+      p.set(
+        "mockNow",
+        new Date(
+          wallClockToUtcMs(DATASETS[dataset].timezone, mockNow)
+        ).toISOString()
+      );
+    }
     else p.delete("mockNow");
     if (mockSpeed) p.set("mockSpeed", mockSpeed);
     else p.delete("mockSpeed");
@@ -96,7 +103,7 @@ export function DebugPanel() {
           <p className="mb-3 font-bold">Debug</p>
 
           <label className="mb-1 block text-xs font-medium text-gray-500">
-            Mock now
+            Mock now (venue time · {DATASETS[dataset].timezone})
           </label>
           <input
             type="datetime-local"

--- a/event-app/src/components/room-screen/RoomScreen.tsx
+++ b/event-app/src/components/room-screen/RoomScreen.tsx
@@ -8,7 +8,8 @@ import APP_CONFIG from "@/CONFIG";
 import { useEvent, useRoom, useSessions } from "@/data/hooks";
 import type { Session } from "@/data/models";
 import { useNowMs } from "@/hooks/useNow";
-import { getStatus, minutesUntil, streamUrlForDay } from "@/components/schedule/utils";
+import { formatTime, getStatus, minutesUntil, streamUrlForDay } from "@/components/schedule/utils";
+import { eventFmt } from "@/data/eventTime";
 import { getTrackTheme } from "@/components/schedule/trackTheme";
 
 // Adapter for the retired trackColor(): the DC8 theme drives the pastel bg;
@@ -20,16 +21,6 @@ const trackColor = (track: string | undefined) => {
 
 const GRADIENT = "linear-gradient(to right, #7a3aff, #633cff, #bc52f1)";
 const GLASS = "bg-white/80 backdrop-blur-[10px]";
-
-const dateFmt = new Intl.DateTimeFormat(undefined, {
-  weekday: "long",
-  month: "short",
-  day: "numeric",
-});
-const timeFmt = new Intl.DateTimeFormat(undefined, {
-  hour: "numeric",
-  minute: "2-digit",
-});
 
 /** "45 min" / "2 hours" / "1 day" — coarse human duration. */
 function humanize(mins: number): string {
@@ -94,7 +85,7 @@ function UpcomingCard({ session }: { session: Session }) {
   return (
     <div className="mb-[0.5em] flex gap-[0.75em] rounded-xl border border-solid border-[#dfd8fc] p-[0.75em]">
       <div className="shrink-0 text-[1.25vw] font-bold tabular-nums">
-        {timeFmt.format(new Date(session.start * 1000))}
+        {formatTime(session.start)}
       </div>
       <div className="min-w-0">
         <p className="line-clamp-3 text-[1vw] font-semibold leading-snug">
@@ -218,11 +209,11 @@ export function RoomScreen({ roomId }: { roomId: string }) {
 
           <div className="m-[0.3em] flex justify-between p-[1em]">
             <p className="ml-[0.2em] text-[1.5vw] text-black">
-              {dateFmt.format(new Date(nowMs))}
+              {eventFmt("en-US", { weekday: "long", month: "short", day: "numeric" }).format(new Date(nowMs))}
             </p>
             <p className="mr-[0.5em] flex items-center gap-[0.75em] text-[1.25vw] font-bold text-black">
               <Clock className="h-[1.5em] w-[1.5em]" style={{ color: "#7D52F4" }} />
-              {timeFmt.format(new Date(nowMs))}
+              {formatTime(nowMs / 1000)}
             </p>
           </div>
 

--- a/event-app/src/components/schedule/FilterStatusBar.tsx
+++ b/event-app/src/components/schedule/FilterStatusBar.tsx
@@ -28,18 +28,16 @@ export function FilterStatusBar({
   if (parts.length === 0) return null;
 
   return (
-    <div className="flex h-9 min-w-0 items-center justify-between gap-2 rounded-[4px] border border-dc-purple bg-dc-lavender px-2 py-1">
+    <button
+      onClick={onClear}
+      aria-label="Clear filters"
+      className="flex h-9 min-w-0 cursor-pointer items-center justify-between gap-2 rounded-[4px] border border-dc-purple bg-dc-lavender px-2 py-1 transition-colors hover:bg-dc-purple-wash"
+    >
       <p className="min-w-0 truncate text-[12px] leading-none text-dc-purple">
         <span className="font-bold">Filter:</span>{" "}
         <span className="font-medium">{parts.join(", ")}</span>
       </p>
-      <button
-        onClick={onClear}
-        aria-label="Clear filters"
-        className="shrink-0 cursor-pointer"
-      >
-        <CircleX className="size-4 text-dc-purple" />
-      </button>
-    </div>
+      <CircleX className="size-4 shrink-0 text-dc-purple" />
+    </button>
   );
 }

--- a/event-app/src/components/schedule/Schedule.tsx
+++ b/event-app/src/components/schedule/Schedule.tsx
@@ -708,15 +708,17 @@ export function Schedule() {
                 {dayHeading && (
                   <h2 className="text-[20px] font-bold leading-[28.8px] tracking-[-0.5px] text-dc-fg2">
                     {dayHeading}
-                    <span className="ml-2 text-[12px] font-normal text-dc-muted">
-                      · {getEventTimeZoneLabel()}
-                    </span>
                   </h2>
                 )}
-                <FilterStatusBar
-                  counts={facetFilterCounts}
-                  onClear={clearFilters}
-                />
+                <div className="flex items-center gap-3">
+                  <FilterStatusBar
+                    counts={facetFilterCounts}
+                    onClear={clearFilters}
+                  />
+                  <span className="text-[14px] tracking-[0] text-dc-muted">
+                    {getEventTimeZoneLabel()}
+                  </span>
+                </div>
               </div>
 
               {/* Mobile applied-filter chip */}

--- a/event-app/src/components/schedule/Schedule.tsx
+++ b/event-app/src/components/schedule/Schedule.tsx
@@ -711,13 +711,14 @@ export function Schedule() {
                   </h2>
                 )}
                 <div className="flex items-center gap-3">
+                  <span className="text-[14px] tracking-[0] text-dc-muted">
+                    {getEventTimeZoneLabel()}
+                  </span>
+                  {/* Outermost so the chip sits under the toolbar's Filter button. */}
                   <FilterStatusBar
                     counts={facetFilterCounts}
                     onClear={clearFilters}
                   />
-                  <span className="text-[14px] tracking-[0] text-dc-muted">
-                    {getEventTimeZoneLabel()}
-                  </span>
                 </div>
               </div>
 

--- a/event-app/src/components/schedule/Schedule.tsx
+++ b/event-app/src/components/schedule/Schedule.tsx
@@ -407,6 +407,7 @@ export function Schedule() {
     days,
     selectedDay,
     setSelectedDay,
+    jumpToToday,
     search,
     setSearch,
     filters,
@@ -434,6 +435,7 @@ export function Schedule() {
   );
   const [scrolled, setScrolled] = useState(false);
   const [timelineJumpSignal, setTimelineJumpSignal] = useState(0);
+  const [listJumpSignal, setListJumpSignal] = useState(0);
   const searchBlockRef = useRef<HTMLDivElement | null>(null);
   const groupRefs = useRef(new Map<string, HTMLElement | null>());
 
@@ -481,13 +483,24 @@ export function Schedule() {
   };
 
   const jumpToNow = () => {
+    // Cross days first: land on the day containing "now" (both view modes only
+    // render the selected day). The scroll itself is signal-driven so it runs
+    // after the (possibly day-switching) re-render, when the target groups /
+    // now line actually exist.
+    jumpToToday();
     if (view === "timeline") {
       // The timeline scrolls itself (horizontally to the now line) on signal.
       setTimelineJumpSignal((n) => n + 1);
       return;
     }
-    // List view: land on the "Live now" section, else a still-running one,
-    // else the next upcoming one.
+    setListJumpSignal((n) => n + 1);
+  };
+
+  // List view "jump to now": land on the "Live now" section, else a
+  // still-running one, else the next upcoming one. Runs as an effect so the
+  // closure sees the just-jumped-to day's groups and their mounted refs.
+  useEffect(() => {
+    if (listJumpSignal === 0) return;
     const target =
       visibleGroups.find((g) => g.isLive) ??
       visibleGroups.find((g) => g.isOngoing) ??
@@ -497,7 +510,8 @@ export function Schedule() {
     groupRefs.current
       .get(target.key)
       ?.scrollIntoView({ behavior: "smooth", block: "start" });
-  };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listJumpSignal]);
 
   // Contiguous live groups render inside one full-bleed band (Figma frame 4).
   const segments = useMemo(() => {

--- a/event-app/src/components/schedule/Schedule.tsx
+++ b/event-app/src/components/schedule/Schedule.tsx
@@ -35,6 +35,7 @@ import { EmptyState } from "./EmptyState";
 import { SessionDetailsPanel } from "./SessionDetailsPanel";
 import { useScheduleState, type DecoratedGroup } from "./useScheduleState";
 import { formatDayHeading } from "./utils";
+import { getEventTimeZoneLabel } from "@/data/eventTime";
 import { useIsDesktop, isDesktopNow } from "@/hooks/useIsDesktop";
 
 type ViewMode = "list" | "timeline";
@@ -536,7 +537,7 @@ export function Schedule() {
   const panelContent = livePanelContent ?? lastPanelContentRef.current;
   const dayHeading = useMemo(() => {
     const day = days.find((d) => d.key === selectedDay);
-    return day ? formatDayHeading(day.sortKey) : null;
+    return day ? formatDayHeading(day.key) : null;
   }, [days, selectedDay]);
 
   const renderGroup = (
@@ -707,6 +708,9 @@ export function Schedule() {
                 {dayHeading && (
                   <h2 className="text-[20px] font-bold leading-[28.8px] tracking-[-0.5px] text-dc-fg2">
                     {dayHeading}
+                    <span className="ml-2 text-[12px] font-normal text-dc-muted">
+                      · {getEventTimeZoneLabel()}
+                    </span>
                   </h2>
                 )}
                 <FilterStatusBar

--- a/event-app/src/components/schedule/useScheduleState.ts
+++ b/event-app/src/components/schedule/useScheduleState.ts
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useState } from "react";
 import type { Session } from "@/data/models";
 import { useNow } from "@/hooks/useNow";
+import { eventDayKey } from "@/data/eventTime";
 import { dayKey, getDays, getStatus, groupByTime, type TimeGroup } from "./utils";
 
 /** Facets a session can be filtered by (each multi-select). */
@@ -80,7 +81,7 @@ export function useScheduleState(
     if (!nowDate) return;
     if (selectedDay && days.some((d) => d.key === selectedDay)) return;
     if (days.length === 0) return;
-    const todayKey = `${nowDate.getFullYear()}-${nowDate.getMonth() + 1}-${nowDate.getDate()}`;
+    const todayKey = eventDayKey(nowDate.getTime());
     setSelectedDay(days.find((day) => day.key === todayKey)?.key ?? days[0].key);
   }, [days, selectedDay, nowDate]);
 

--- a/event-app/src/components/schedule/useScheduleState.ts
+++ b/event-app/src/components/schedule/useScheduleState.ts
@@ -98,6 +98,19 @@ export function useScheduleState(
     if (target !== selectedDay) setSelectedDayState(target);
   }, [days, selectedDay, nowDate, userPickedDay]);
 
+  // "Jump to now" crosses days: land on the day containing `now` — clamped to
+  // the dataset's range (before day 1 → day 1, after the event → last day) —
+  // and resume auto-following today, since the user just re-synced with the
+  // clock. Days are sorted ascending, so the first key >= today is the clamp.
+  const jumpToToday = () => {
+    setUserPickedDay(false);
+    if (days.length === 0) return;
+    const todayKey = eventDayKey(now);
+    const target =
+      days.find((d) => d.key >= todayKey)?.key ?? days[days.length - 1].key;
+    setSelectedDayState(target);
+  };
+
   const filterOptions = useMemo(() => {
     const opts: Record<FilterFacet, string[]> = {
       track: [],
@@ -265,6 +278,7 @@ export function useScheduleState(
     days,
     selectedDay,
     setSelectedDay,
+    jumpToToday,
     search,
     setSearch,
     filters,

--- a/event-app/src/components/schedule/useScheduleState.ts
+++ b/event-app/src/components/schedule/useScheduleState.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import type { Session } from "@/data/models";
 import { useNow } from "@/hooks/useNow";
 import { eventDayKey } from "@/data/eventTime";
@@ -69,21 +69,34 @@ export function useScheduleState(
   const now = nowDate ? nowDate.getTime() : Date.now();
   const days = useMemo(() => getDays(sessions), [sessions]);
 
-  const [selectedDay, setSelectedDay] = useState<string | null>(null);
+  const [selectedDay, setSelectedDayState] = useState<string | null>(null);
+  // Sticky once the user taps a tab: auto-following "today" stops so the
+  // clock (real or mocked) never fights an explicit choice.
+  const [userPickedDay, setUserPickedDay] = useState(false);
+  const setSelectedDay = useCallback((key: string) => {
+    setUserPickedDay(true);
+    setSelectedDayState(key);
+  }, []);
   const [search, setSearch] = useState("");
   const [filters, setFilters] = useState<Filters>(EMPTY);
   const [interestedOnly, setInterestedOnly] = useState(false);
 
-  // Default to today if the event is running, otherwise the first day.
-  // "Today" derives from the mockable `now`, so `?mockNow=` selects the
-  // matching day (a raw `new Date()` here used to break that).
+  // Follow "today" (venue time) until the user picks a day: the initial load
+  // lands on today if the event is running (else day 1), and the tab advances
+  // when the clock crosses venue midnight. "Today" derives from the mockable
+  // `now`, so `?mockNow=` selects — and `mockSpeed` advances — the matching day.
   useEffect(() => {
-    if (!nowDate) return;
-    if (selectedDay && days.some((d) => d.key === selectedDay)) return;
-    if (days.length === 0) return;
+    if (!nowDate || days.length === 0) return;
+    const selectionValid =
+      selectedDay != null && days.some((d) => d.key === selectedDay);
+    if (userPickedDay && selectionValid) return;
     const todayKey = eventDayKey(nowDate.getTime());
-    setSelectedDay(days.find((day) => day.key === todayKey)?.key ?? days[0].key);
-  }, [days, selectedDay, nowDate]);
+    const today = days.find((day) => day.key === todayKey)?.key ?? null;
+    // Outside the event (before day 1 / after the last day) keep whatever
+    // valid day is showing; only the initial null falls back to day 1.
+    const target = today ?? (selectionValid ? selectedDay : days[0].key);
+    if (target !== selectedDay) setSelectedDayState(target);
+  }, [days, selectedDay, nowDate, userPickedDay]);
 
   const filterOptions = useMemo(() => {
     const opts: Record<FilterFacet, string[]> = {

--- a/event-app/src/components/schedule/utils.ts
+++ b/event-app/src/components/schedule/utils.ts
@@ -1,40 +1,41 @@
 import type { Room, Session } from "@/data/models";
+import { dayKeyToUtcMidnightMs, eventDayKey, eventFmt } from "@/data/eventTime";
 
 /** Session timing is stored as unix seconds. */
 const ms = (unixSeconds: number) => unixSeconds * 1000;
 
-/** Stable key for the calendar day a session starts on (local time). */
+/**
+ * Stable key ("YYYY-MM-DD") for the calendar day a session starts on, in the
+ * event's venue timezone — so day grouping is identical for every viewer.
+ */
 export function dayKey(session: Session): string {
-  const d = new Date(ms(session.start));
-  return `${d.getFullYear()}-${d.getMonth() + 1}-${d.getDate()}`;
+  return eventDayKey(ms(session.start));
 }
 
-const dayLabelFmt = new Intl.DateTimeFormat(undefined, {
-  weekday: "short",
-  month: "short",
-  day: "numeric",
-});
-// 24-hour, zero-padded ("09:30") per the Figma design.
-const timeFmt = new Intl.DateTimeFormat("en-GB", {
-  hour: "2-digit",
-  minute: "2-digit",
-  hour12: false,
-});
+// All formatters are pinned to the event timezone (via eventFmt) and to a
+// fixed locale — DayTabs/ScheduleTimeline parse the labels with split(", ").
 
+// "Tue, Nov 12" — day-tab label.
 export const formatDayLabel = (session: Session) =>
-  dayLabelFmt.format(new Date(ms(session.start)));
+  eventFmt("en-US", { weekday: "short", month: "short", day: "numeric" })
+    .format(new Date(ms(session.start)));
 
 // "Wed, November 13" — the desktop list's day heading (Figma "Tues, November 3").
+// Takes a "YYYY-MM-DD" day key; formats its synthetic UTC midnight in UTC
+// (static — not eventFmt — because the key already encodes the venue day).
 const dayHeadingFmt = new Intl.DateTimeFormat("en-US", {
   weekday: "short",
   month: "long",
   day: "numeric",
+  timeZone: "UTC",
 });
-export const formatDayHeading = (startOfDayMs: number) =>
-  dayHeadingFmt.format(new Date(startOfDayMs));
+export const formatDayHeading = (key: string) =>
+  dayHeadingFmt.format(new Date(dayKeyToUtcMidnightMs(key)));
 
+// 24-hour, zero-padded ("09:30") per the Figma design.
 export const formatTime = (unixSeconds: number) =>
-  timeFmt.format(new Date(ms(unixSeconds)));
+  eventFmt("en-GB", { hour: "2-digit", minute: "2-digit", hour12: false })
+    .format(new Date(ms(unixSeconds)));
 
 export const formatTimeRange = (session: Session) =>
   `${formatTime(session.start)} – ${formatTime(session.end)}`;
@@ -59,7 +60,7 @@ export function minutesUntil(session: Session, nowMs: number): number {
 export interface ScheduleDay {
   key: string;
   label: string;
-  /** Start-of-day timestamp, for sorting and "is today". */
+  /** Synthetic UTC midnight (ms) of the venue day — for sorting only. */
   sortKey: number;
 }
 
@@ -69,9 +70,11 @@ export function getDays(sessions: Session[]): ScheduleDay[] {
   for (const s of sessions) {
     const key = dayKey(s);
     if (!map.has(key)) {
-      const d = new Date(ms(s.start));
-      d.setHours(0, 0, 0, 0);
-      map.set(key, { key, label: formatDayLabel(s), sortKey: d.getTime() });
+      map.set(key, {
+        key,
+        label: formatDayLabel(s),
+        sortKey: dayKeyToUtcMidnightMs(key),
+      });
     }
   }
   return [...map.values()].sort((a, b) => a.sortKey - b.sortKey);
@@ -192,8 +195,9 @@ export const STREAM_FIELDS = [
 
 /**
  * 1-based conference day for a timestamp, anchored on the event's startDate
- * (UTC calendar days). Null when event dates are unknown or the timestamp
- * falls outside the covered range.
+ * (venue-timezone calendar days, matching the schedule's day grouping). Null
+ * when event dates are unknown or the timestamp falls outside the covered
+ * range.
  */
 export function eventDayIndex(
   tMs: number,
@@ -203,7 +207,10 @@ export function eventDayIndex(
   const eventStartMs = Date.parse(eventStartIso);
   if (Number.isNaN(eventStartMs)) return null;
   const index =
-    Math.floor(tMs / DAY_MS) - Math.floor(eventStartMs / DAY_MS) + 1;
+    (dayKeyToUtcMidnightMs(eventDayKey(tMs)) -
+      dayKeyToUtcMidnightMs(eventDayKey(eventStartMs))) /
+      DAY_MS +
+    1;
   return index >= 1 && index <= STREAM_FIELDS.length ? index : null;
 }
 

--- a/event-app/src/data/dataset.ts
+++ b/event-app/src/data/dataset.ts
@@ -18,6 +18,12 @@ export interface Dataset {
    * the selected conference so schedule/live/today logic lands on day 1.
    */
   startDate: string;
+  /**
+   * IANA timezone of the venue. All session times render in this zone (the
+   * API serves plain UTC instants and no timezone), so the schedule reads the
+   * same everywhere in the world — see src/data/eventTime.ts.
+   */
+  timezone: string;
 }
 
 const ENV_API =
@@ -32,6 +38,7 @@ export const DATASETS: Record<DatasetKey, Dataset> = {
     eventId: "test-devcon-8",
     // 2026-11-03 09:00 Asia/Kolkata (UTC+5:30)
     startDate: "2026-11-03T03:30:00Z",
+    timezone: "Asia/Kolkata",
   },
   devcon8: {
     key: "devcon8",
@@ -40,6 +47,7 @@ export const DATASETS: Record<DatasetKey, Dataset> = {
     eventId: "devcon8",
     // 2026-11-03 09:00 Asia/Kolkata (UTC+5:30)
     startDate: "2026-11-03T03:30:00Z",
+    timezone: "Asia/Kolkata",
   },
   "devcon-7": {
     key: "devcon-7",
@@ -49,6 +57,7 @@ export const DATASETS: Record<DatasetKey, Dataset> = {
     // Day 2 peak: 2024-11-13 15:30 Asia/Bangkok (UTC+7) — ~17 rooms live, so the
     // room screens and schedule look full on load.
     startDate: "2024-11-13T08:30:00Z",
+    timezone: "Asia/Bangkok",
   },
 };
 

--- a/event-app/src/data/eventTime.ts
+++ b/event-app/src/data/eventTime.ts
@@ -55,6 +55,57 @@ export function dayKeyToUtcMidnightMs(key: string): number {
   return Date.UTC(y, m - 1, d);
 }
 
+// --- Explicit-timezone wall-clock converters ---------------------------------
+// Used by the debug panel, which must convert against its *selected* dataset's
+// timezone, not the URL-active one the helpers above read.
+
+const wallClockFmt = (tz: string) =>
+  new Intl.DateTimeFormat("en-US", {
+    timeZone: tz,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    second: "2-digit",
+    hourCycle: "h23", // not hour12:false, which can yield "24:00"
+  });
+
+/** Offset (ms) of `tz` from UTC at instant tMs (positive east of UTC). */
+function tzOffsetMs(tz: string, tMs: number): number {
+  const parts = wallClockFmt(tz).formatToParts(new Date(tMs));
+  const get = (type: string) =>
+    Number(parts.find((p) => p.type === type)?.value ?? 0);
+  const asUtc = Date.UTC(
+    get("year"),
+    get("month") - 1,
+    get("day"),
+    get("hour"),
+    get("minute"),
+    get("second")
+  );
+  return asUtc - (tMs - (tMs % 1000));
+}
+
+/** UTC instant (ms) for a "YYYY-MM-DDTHH:mm" wall-clock time in `tz`. */
+export function wallClockToUtcMs(tz: string, wallClock: string): number {
+  const [date, time] = wallClock.split("T");
+  const [y, m, d] = date.split("-").map(Number);
+  const [h, min] = time.split(":").map(Number);
+  const naive = Date.UTC(y, m - 1, d, h, min);
+  // Two passes: exact in one for fixed-offset zones, second guards DST zones.
+  let t = naive - tzOffsetMs(tz, naive);
+  t = naive - tzOffsetMs(tz, t);
+  return t;
+}
+
+/** "YYYY-MM-DDTHH:mm" wall clock in `tz` for a UTC instant (datetime-local format). */
+export function utcMsToWallClock(tz: string, tMs: number): string {
+  const parts = wallClockFmt(tz).formatToParts(new Date(tMs));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}`;
+}
+
 /** Short human label for the venue zone, e.g. "Bangkok time (GMT+7)". */
 export function getEventTimeZoneLabel(): string {
   const tz = getEventTimeZone();

--- a/event-app/src/data/eventTime.ts
+++ b/event-app/src/data/eventTime.ts
@@ -99,11 +99,20 @@ export function wallClockToUtcMs(tz: string, wallClock: string): number {
   return t;
 }
 
-/** "YYYY-MM-DDTHH:mm" wall clock in `tz` for a UTC instant (datetime-local format). */
-export function utcMsToWallClock(tz: string, tMs: number): string {
+/**
+ * "YYYY-MM-DDTHH:mm" wall clock in `tz` for a UTC instant (datetime-local
+ * format). `withSeconds` appends ":ss" (debug clock; not valid for
+ * datetime-local inputs).
+ */
+export function utcMsToWallClock(
+  tz: string,
+  tMs: number,
+  withSeconds = false
+): string {
   const parts = wallClockFmt(tz).formatToParts(new Date(tMs));
   const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
-  return `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}`;
+  const base = `${get("year")}-${get("month")}-${get("day")}T${get("hour")}:${get("minute")}`;
+  return withSeconds ? `${base}:${get("second")}` : base;
 }
 
 /** Short human label for the venue zone, e.g. "Bangkok time (GMT+7)". */

--- a/event-app/src/data/eventTime.ts
+++ b/event-app/src/data/eventTime.ts
@@ -1,0 +1,68 @@
+import { getActiveDataset } from "./dataset";
+
+/**
+ * Event-timezone rendering helpers. The API serves session times as plain UTC
+ * instants with no timezone, so every wall-clock string in the app must be
+ * produced through these helpers pinned to the venue's timezone — otherwise
+ * the schedule (times AND day grouping) shifts with the viewer's system zone.
+ */
+
+/** IANA timezone of the active event's venue. */
+export function getEventTimeZone(): string {
+  return getActiveDataset().timezone;
+}
+
+// Built lazily (not at module scope) so the `?dataset` param — read at call
+// time by getActiveDataset() — is respected. Keyed by tz too, defensively.
+const fmtCache = new Map<string, Intl.DateTimeFormat>();
+
+/** Cached Intl.DateTimeFormat pinned to the event timezone. */
+export function eventFmt(
+  locale: string,
+  options: Intl.DateTimeFormatOptions
+): Intl.DateTimeFormat {
+  const timeZone = getEventTimeZone();
+  const key = `${timeZone}|${locale}|${JSON.stringify(options)}`;
+  let fmt = fmtCache.get(key);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat(locale, { ...options, timeZone });
+    fmtCache.set(key, fmt);
+  }
+  return fmt;
+}
+
+/**
+ * "YYYY-MM-DD" calendar day of an instant in the event timezone. Zero-padded,
+ * so string comparison sorts chronologically.
+ */
+export function eventDayKey(tMs: number): string {
+  const parts = eventFmt("en-US", {
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).formatToParts(new Date(tMs));
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")}`;
+}
+
+/**
+ * UTC midnight (ms) of a "YYYY-MM-DD" day key — a synthetic timestamp for
+ * exact day arithmetic and sorting. Format it with a UTC-pinned formatter,
+ * never a local or event-tz one.
+ */
+export function dayKeyToUtcMidnightMs(key: string): number {
+  const [y, m, d] = key.split("-").map(Number);
+  return Date.UTC(y, m - 1, d);
+}
+
+/** Short human label for the venue zone, e.g. "Bangkok time (GMT+7)". */
+export function getEventTimeZoneLabel(): string {
+  const tz = getEventTimeZone();
+  const city = (tz.split("/").pop() ?? tz).replace(/_/g, " ");
+  // Static label: the zones we use don't observe DST, so the current offset
+  // is the event's offset (no useNow needed).
+  const offset = eventFmt("en-US", { timeZoneName: "shortOffset" })
+    .formatToParts(new Date())
+    .find((p) => p.type === "timeZoneName")?.value;
+  return offset ? `${city} time (${offset})` : `${city} time`;
+}

--- a/event-app/src/data/providers/devcon-api.provider.ts
+++ b/event-app/src/data/providers/devcon-api.provider.ts
@@ -1,5 +1,6 @@
 import type { ConferenceEvent, Room, Session, Speaker } from "../models";
 import { datasetForEventId, getActiveDataset } from "../dataset";
+import { dayKeyToUtcMidnightMs, eventDayKey } from "../eventTime";
 import { BaseProvider, type SessionFilters } from "./provider-interface";
 
 export class DevconApiProvider extends BaseProvider {
@@ -28,7 +29,10 @@ export class DevconApiProvider extends BaseProvider {
     const end = Math.floor(endMs / 1000);
     const duration = end - start;
 
-    const startDate = startMs ? new Date(startMs) : null;
+    // Day fields are derived in the venue timezone (like the schedule UI),
+    // via the day key's synthetic UTC midnight.
+    const date = startMs ? eventDayKey(startMs) : undefined;
+    const utcMid = date ? new Date(dayKeyToUtcMidnightMs(date)) : null;
     const days = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
 
     return {
@@ -42,9 +46,9 @@ export class DevconApiProvider extends BaseProvider {
       duration,
       start,
       end,
-      day: startDate ? String(startDate.getDay()) : undefined,
-      date: startDate ? startDate.toISOString().split("T")[0] : undefined,
-      dayOfWeek: startDate ? days[startDate.getDay()] : undefined,
+      day: utcMid ? String(utcMid.getUTCDay()) : undefined,
+      date,
+      dayOfWeek: utcMid ? days[utcMid.getUTCDay()] : undefined,
       room: raw.slot_room
         ? this.mapRoom(raw.slot_room)
         : undefined,

--- a/event-app/src/hooks/useNow.ts
+++ b/event-app/src/hooks/useNow.ts
@@ -36,8 +36,17 @@ const AUTO_MOCK_EVENT_START =
  *
  *   ?mockNow=nov17&mockSpeed=10
  *
+ * When a mock is active, the tick interval is divided by the speed (floored at
+ * 250ms) so consumers refresh per *mocked* minute, not per real minute — a 60s
+ * caller at ×60 re-renders every real second. All hook instances share one
+ * clock anchor per (mockNow, mockSpeed), so navigating between pages never
+ * rewinds the mock clock and concurrent components agree; a full page reload
+ * restarts the clock at `mockNow` (matches the debug panel's "Apply & reload").
+ *
  * Returns `null` during SSR / first paint to avoid hydration mismatch — callers
- * should treat that as "loading" (e.g. fall back to `Date.now()`).
+ * should treat that as "loading" (e.g. fall back to `Date.now()`). Note the
+ * `useNowMs` fallback is the *real* clock, so a mocked page's very first frame
+ * can render against real time before the effect corrects it.
  */
 
 // Force any input without an explicit timezone marker into UTC.
@@ -81,6 +90,20 @@ function readParam(name: string): string | null {
   return new URLSearchParams(window.location.search).get(name);
 }
 
+// One clock anchor per (mockStart, speed): every hook instance and remount
+// shares it, so client-side navigation doesn't rewind the mock clock and
+// concurrently-mounted components agree on the time. Module state — survives
+// remounts; reset by a full reload (intended: "Apply & reload" restarts the
+// clock at `mockNow`) and by editing this file under Fast Refresh.
+let sharedAnchor: { key: string; realStart: number } | null = null;
+function getSharedRealStart(mockStart: number, speed: number): number {
+  const key = `${mockStart}|${speed}`;
+  if (!sharedAnchor || sharedAnchor.key !== key) {
+    sharedAnchor = { key, realStart: Date.now() };
+  }
+  return sharedAnchor.realStart;
+}
+
 export function useNow(
   intervalMs: number = 1000,
   options: { autoMockEventStart?: boolean } = {}
@@ -103,7 +126,6 @@ export function useNow(
   }>({ mockStart: null, realStart: 0, speed: 1 });
 
   useEffect(() => {
-    const realStart = Date.now();
     // Explicit `?mockNow` always wins; otherwise fall back to the active
     // dataset's conference start when preview auto-mock is enabled.
     let mockStart = mockNowParam ? parseMockNow(mockNowParam) : null;
@@ -113,6 +135,8 @@ export function useNow(
     }
     const parsedSpeed = mockSpeedParam ? parseFloat(mockSpeedParam) : NaN;
     const speed = isNaN(parsedSpeed) || parsedSpeed <= 0 ? 1 : parsedSpeed;
+    const realStart =
+      mockStart != null ? getSharedRealStart(mockStart, speed) : Date.now();
 
     baseRef.current = { mockStart, realStart, speed };
 
@@ -125,8 +149,16 @@ export function useNow(
       return new Date();
     }
 
+    // Tick per *mocked* interval when accelerated, so a 60s caller still sees
+    // every mocked minute at ×60. Floored at 250ms to bound CPU at extreme
+    // speeds; speeds < 1 never tick slower than the caller asked for.
+    const effectiveInterval =
+      mockStart != null && speed > 1
+        ? Math.max(250, Math.min(intervalMs, intervalMs / speed))
+        : intervalMs;
+
     setNow(compute());
-    const id = setInterval(() => setNow(compute()), intervalMs);
+    const id = setInterval(() => setNow(compute()), effectiveInterval);
     return () => clearInterval(id);
   }, [intervalMs, mockNowParam, mockSpeedParam, autoMockEventStart]);
 


### PR DESCRIPTION
Session times in the PWA rendered in whatever timezone the viewer's device was set to (a California user saw Devcon 7 day 1 starting Monday evening, Nov 11). The API data was always correct UTC — the app just had no concept of an event timezone. 

**Everything now renders in venue time** — Asia/Bangkok (UTC +7) for DC7, and Asia/Kolkata (UTC +5:30) for DC8 datasets.

- **Render session times in the event venue timezone** — per-dataset IANA timezone in `dataset.ts` + new `eventTime.ts` helpers (tz-pinned Intl formatters, venue day keys); schedule formatting, day grouping, "today" tab, livestream day index, room screen, and provider day fields all switch to venue time. ICS export and announcements intentionally untouched.
- **Debug panel mocks in venue time; restyle tz label** — the Mock-now field now reads/writes venue wall-clock time instead of viewer-local (`?mockNow=` stays a UTC instant); the day-heading timezone label moves to the row's flex-end at 14px.
- **Filter chip outermost in heading row** — the applied-filters indicator sits at the far right, directly under the toolbar's Filter button.
- **Whole filter chip clears filters** — the full pill is the button (with wash hover tint) instead of just the 16px X, fixing the small tap target.

Verified headless in America/Los_Angeles, Europe/London, and Pacific/Kiritimati: Opening Ceremony renders 10:00 Tue Nov 12 everywhere.