### PR TITLE
Add Aadhaar QR 2 hour expiry notice to SelfVerificationModal

### DIFF
--- a/devcon/src/components/domain/tickets/SelfVerificationModal.tsx
+++ b/devcon/src/components/domain/tickets/SelfVerificationModal.tsx
@@ -425,6 +425,11 @@ export function SelfVerificationModal({
                     </ul>
                   </div>
 
+                  <div className={css['self-expiry-note']}>
+                    <strong>Your Aadhaar QR code expires after 2 hours</strong>. Download your Aadhaar right before
+                    adding it to Self — older codes fail without a clear error.
+                  </div>
+
                   <div className={css['self-howto']}>
                     <h3 className={css['self-heading']}>How to verify</h3>
                     <ul className={css['self-steps']}>

--- a/devcon/src/components/domain/tickets/VerificationModal.module.scss
+++ b/devcon/src/components/domain/tickets/VerificationModal.module.scss
@@ -548,6 +548,15 @@
   margin: 0;
 }
 
+.self-expiry-note {
+  background: #fff8e1;
+  border-radius: 4px;
+  padding: 0.75rem 1rem;
+  font-size: 0.875rem;
+  color: #1a0d33;
+  line-height: 1.43;
+}
+
 /* Stacked on mobile; 2-col grid (content left, QR right) from 768px up */
 .self-columns {
   display: flex;


### PR DESCRIPTION
- Introduced a note in the SelfVerificationModal to inform users that their Aadhaar QR code expires after 2 hours, advising them to download it just before use.
- Added corresponding styles for the self-expiry note to enhance visibility and user experience.