### PR TITLE
Add rtd communities nocodb sync

### DIFF
--- a/devcon/content/en/intl/road_to_devcon.json
+++ b/devcon/content/en/intl/road_to_devcon.json
@@ -46,7 +46,8 @@
     "eyebrow": "Our co-creators",
     "title": "Road to Devcon communities",
     "cta_text": "Want to help create Devcon with us?",
-    "cta_button": "Get in touch"
+    "cta_button": "Get in touch",
+    "load_more": "Load more"
   },
   "programs": {
     "title": "Join the Devcon Programs",

--- a/devcon/src/components/domain/road-to-devcon/RoadToDevconCommunities.tsx
+++ b/devcon/src/components/domain/road-to-devcon/RoadToDevconCommunities.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import cn from 'classnames'
 import { Link } from 'components/common/link'
 import { ctaSecondary } from 'components/common/cta'
@@ -40,15 +40,16 @@ export function RoadToDevconCommunities({ communities }: { communities: RoadComm
   const [showAll, setShowAll] = useState(false)
   // The random pick happens on the client only: SSR renders the server order
   // (invisible), then the grid fades in once shuffled — no hydration mismatch
-  // and no visible reorder.
-  const [mounted, setMounted] = useState(false)
+  // and no visible reorder. null = not shuffled yet.
+  const [shuffled, setShuffled] = useState<RoadCommunity[] | null>(null)
   useEffect(() => {
-    setMounted(true)
-  }, [])
+    setShuffled(shuffle(communities))
+  }, [communities])
 
-  const shuffled = useMemo(() => (mounted ? shuffle(communities) : communities), [communities, mounted])
-  const visible = showAll ? shuffled : shuffled.slice(0, INITIAL_COUNT)
-  const hasMore = communities.length > INITIAL_COUNT && !showAll
+  const mounted = shuffled !== null
+  const list = shuffled ?? communities
+  const visible = showAll ? list : list.slice(0, INITIAL_COUNT)
+  const hasMore = visible.length < list.length
 
   return (
     <section className="section relative z-10 bg-[#ffe6f1] py-16 text-[#160b2b]">

--- a/devcon/src/components/domain/road-to-devcon/RoadToDevconCommunities.tsx
+++ b/devcon/src/components/domain/road-to-devcon/RoadToDevconCommunities.tsx
@@ -1,27 +1,55 @@
-import React from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
+import cn from 'classnames'
 import { Link } from 'components/common/link'
+import { ctaSecondary } from 'components/common/cta'
 import { ArrowRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
-
-// Community logos live in public/road-to-devcon/communities/ — same convention
-// the rest of the Road to Devcon feature uses (Hero/Programs load from here).
-const ASSET_BASE = '/road-to-devcon/communities'
+import { shuffle } from 'utils/shuffle'
+import type { RoadCommunity } from './communities'
 
 // "Want to help create Devcon with us?" → email the ecosystem team.
 const CONTACT_URL = 'mailto:ecosystem@devcon.org'
 
-// The 4 Road to Devcon community co-creators (order per the design). Logos are
-// wordmark PNGs sized to a uniform height (ETH Mumbai bakes its own white pill
-// into the asset).
-const COMMUNITIES = [
-  { name: 'Devfolio', src: `${ASSET_BASE}/devfolio.png`, href: 'https://devfolio.co/discover' },
-  { name: 'ETH Mumbai', src: `${ASSET_BASE}/eth-mumbai.png`, href: 'https://www.ethmumbai.in/' },
-  { name: 'Aya', src: `${ASSET_BASE}/aya.png`, href: 'https://theayacommunity.com/' },
-  { name: 'ETH Pune', src: `${ASSET_BASE}/eth-pune.png`, href: 'https://www.ethpune.com/' },
-]
+// How many logos show before "Load more" reveals the rest.
+const INITIAL_COUNT = 10
 
-export function RoadToDevconCommunities() {
+function CommunityLogo({ community }: { community: RoadCommunity }) {
+  const className = 'flex h-10 shrink-0 items-center justify-center transition-transform hover:scale-105 sm:h-14'
+  // Logos are pre-sized WebPs (or SVGs) served from Supabase's CDN; a plain
+  // <img> avoids /_next/image re-transforming them for no gain.
+  const img = (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={community.logo}
+      alt={community.name}
+      loading="lazy"
+      decoding="async"
+      className="h-full w-auto object-contain"
+    />
+  )
+  if (!community.url) return <span className={className}>{img}</span>
+  return (
+    <Link to={community.url} className={className}>
+      {img}
+    </Link>
+  )
+}
+
+export function RoadToDevconCommunities({ communities }: { communities: RoadCommunity[] }) {
   const t = useTranslations('road_to_devcon')
+  const [showAll, setShowAll] = useState(false)
+  // The random pick happens on the client only: SSR renders the server order
+  // (invisible), then the grid fades in once shuffled — no hydration mismatch
+  // and no visible reorder.
+  const [mounted, setMounted] = useState(false)
+  useEffect(() => {
+    setMounted(true)
+  }, [])
+
+  const shuffled = useMemo(() => (mounted ? shuffle(communities) : communities), [communities, mounted])
+  const visible = showAll ? shuffled : shuffled.slice(0, INITIAL_COUNT)
+  const hasMore = communities.length > INITIAL_COUNT && !showAll
+
   return (
     <section className="section relative z-10 bg-[#ffe6f1] py-16 text-[#160b2b]">
       {/* Stacked & centered on mobile → tablet → sm-desktop; on xl the heading +
@@ -51,18 +79,23 @@ export function RoadToDevconCommunities() {
           </div>
         </div>
 
-        {/* Logos — wrap 2×2 on mobile/tablet, single row on lg+ */}
-        <div className="order-2 flex w-full flex-wrap items-center justify-center gap-x-12 gap-y-8 xl:order-none">
-          {COMMUNITIES.map(community => (
-            <Link
-              key={community.name}
-              to={community.href}
-              className="flex h-10 shrink-0 items-center justify-center transition-transform hover:scale-105 sm:h-14"
-            >
-              {/* eslint-disable-next-line @next/next/no-img-element */}
-              <img src={community.src} alt={community.name} className="h-full w-auto object-contain" />
-            </Link>
-          ))}
+        {/* Logos (+ Load more) — wrap on mobile/tablet, single row on lg+ */}
+        <div className="order-2 flex w-full flex-col items-center gap-8 xl:order-none">
+          <div
+            className={cn(
+              'flex w-full flex-wrap items-center justify-center gap-x-12 gap-y-8 transition-opacity duration-150 ease-out',
+              mounted ? 'opacity-100' : 'opacity-0'
+            )}
+          >
+            {visible.map(community => (
+              <CommunityLogo key={community.id} community={community} />
+            ))}
+          </div>
+          {hasMore && (
+            <button type="button" className={ctaSecondary} onClick={() => setShowAll(true)}>
+              {t('communities.load_more')}
+            </button>
+          )}
         </div>
       </div>
     </section>

--- a/devcon/src/components/domain/road-to-devcon/communities.ts
+++ b/devcon/src/components/domain/road-to-devcon/communities.ts
@@ -1,0 +1,25 @@
+// Road to Devcon community co-creators shown as a logo wall on /road-to-devcon.
+//
+// The live list comes from the NocoDB "RTD Communities Logos" table
+// (services/rtd-communities.ts). This seed is only the build-time fallback used
+// when NocoDB is unreachable, so the section is never empty.
+
+export interface RoadCommunity {
+  id: string
+  name: string
+  /** Logo URL (public Supabase Storage URL mirrored from NocoDB, or a local asset for the seed). */
+  logo: string
+  // null (not undefined) when missing — getStaticProps can't serialize undefined.
+  url: string | null
+}
+
+// Logos live in public/road-to-devcon/communities/ — same convention the rest
+// of the Road to Devcon feature uses (Hero/Programs load from here).
+const ASSET_BASE = '/road-to-devcon/communities'
+
+export const ROAD_TO_DEVCON_COMMUNITIES: RoadCommunity[] = [
+  { id: 'seed-devfolio', name: 'Devfolio', logo: `${ASSET_BASE}/devfolio.png`, url: 'https://devfolio.co/discover' },
+  { id: 'seed-eth-mumbai', name: 'ETH Mumbai', logo: `${ASSET_BASE}/eth-mumbai.png`, url: 'https://www.ethmumbai.in/' },
+  { id: 'seed-aya', name: 'Aya', logo: `${ASSET_BASE}/aya.png`, url: 'https://theayacommunity.com/' },
+  { id: 'seed-eth-pune', name: 'ETH Pune', logo: `${ASSET_BASE}/eth-pune.png`, url: 'https://www.ethpune.com/' },
+]

--- a/devcon/src/pages/road-to-devcon.tsx
+++ b/devcon/src/pages/road-to-devcon.tsx
@@ -10,7 +10,9 @@ import { University, Sprout, ArrowRight } from 'lucide-react'
 import { useTranslations } from 'next-intl'
 import { getMessages } from 'utils/intl'
 import { getRoadToDevconEvents } from 'services/rtd-events'
+import { getRoadToDevconCommunities } from 'services/rtd-communities'
 import { ROAD_TO_DEVCON_EVENTS, type RoadEvent } from 'components/domain/road-to-devcon/events'
+import { ROAD_TO_DEVCON_COMMUNITIES, type RoadCommunity } from 'components/domain/road-to-devcon/communities'
 import themes from './themes.module.scss'
 import css from './road-to-devcon.module.scss'
 
@@ -82,7 +84,13 @@ function AboutSection() {
   )
 }
 
-export default function RoadToDevconPage({ events }: { events: RoadEvent[] }) {
+export default function RoadToDevconPage({
+  events,
+  communities,
+}: {
+  events: RoadEvent[]
+  communities: RoadCommunity[]
+}) {
   return (
     <div className={`${css['layout']} ${themes['index']}`}>
       <Header withHero />
@@ -94,7 +102,7 @@ export default function RoadToDevconPage({ events }: { events: RoadEvent[] }) {
 
         <RoadToDevconEvents events={events} />
 
-        <RoadToDevconCommunities />
+        <RoadToDevconCommunities communities={communities} />
 
         <RoadToDevconPrograms />
 
@@ -118,8 +126,18 @@ export async function getStaticProps(context: any) {
     console.error('[road-to-devcon] event fetch failed, using seed:', e)
     events = ROAD_TO_DEVCON_EVENTS
   }
+  // Community logos come from the NocoDB "RTD Communities Logos" table on the
+  // same ISR cadence, with the bundled seed as the offline fallback.
+  let communities: RoadCommunity[]
+  try {
+    communities = await getRoadToDevconCommunities()
+  } catch (e) {
+    console.error('[road-to-devcon] communities fetch failed, using seed:', e)
+    communities = ROAD_TO_DEVCON_COMMUNITIES
+  }
   // getStaticProps can't serialize `undefined`; round-trip through JSON to drop
   // any undefined-valued optional fields so a missing value never crashes the page.
   const safeEvents: RoadEvent[] = JSON.parse(JSON.stringify(events))
-  return { props: { events: safeEvents, messages }, revalidate: 1800 }
+  const safeCommunities: RoadCommunity[] = JSON.parse(JSON.stringify(communities))
+  return { props: { events: safeEvents, communities: safeCommunities, messages }, revalidate: 1800 }
 }

--- a/devcon/src/pages/road-to-devcon.tsx
+++ b/devcon/src/pages/road-to-devcon.tsx
@@ -116,28 +116,22 @@ export async function getStaticProps(context: any) {
   const locale: string = context.locale ?? 'en'
   const messages = await getMessages(locale)
 
-  // Build the events into the page (ISR, 30 min) so they're always present —
-  // no client fetch / loading state. Falls back to the bundled seed if NocoDB
-  // is unreachable at build/revalidate time so the section is never empty.
-  let events: RoadEvent[]
-  try {
-    events = await getRoadToDevconEvents()
-  } catch (e) {
-    console.error('[road-to-devcon] event fetch failed, using seed:', e)
-    events = ROAD_TO_DEVCON_EVENTS
+  // Build the NocoDB-backed sections into the page (ISR, 30 min) so they're
+  // always present — no client fetch / loading state. Each falls back to its
+  // bundled seed if NocoDB is unreachable at build/revalidate time, so a
+  // section is never empty. getStaticProps can't serialize `undefined`, so the
+  // result is round-tripped through JSON to drop any undefined-valued fields.
+  const loadWithSeed = async <T,>(label: string, load: () => Promise<T>, seed: T): Promise<T> => {
+    try {
+      return JSON.parse(JSON.stringify(await load()))
+    } catch (e) {
+      console.error(`[road-to-devcon] ${label} fetch failed, using seed:`, e)
+      return seed
+    }
   }
-  // Community logos come from the NocoDB "RTD Communities Logos" table on the
-  // same ISR cadence, with the bundled seed as the offline fallback.
-  let communities: RoadCommunity[]
-  try {
-    communities = await getRoadToDevconCommunities()
-  } catch (e) {
-    console.error('[road-to-devcon] communities fetch failed, using seed:', e)
-    communities = ROAD_TO_DEVCON_COMMUNITIES
-  }
-  // getStaticProps can't serialize `undefined`; round-trip through JSON to drop
-  // any undefined-valued optional fields so a missing value never crashes the page.
-  const safeEvents: RoadEvent[] = JSON.parse(JSON.stringify(events))
-  const safeCommunities: RoadCommunity[] = JSON.parse(JSON.stringify(communities))
-  return { props: { events: safeEvents, communities: safeCommunities, messages }, revalidate: 1800 }
+  const [events, communities] = await Promise.all([
+    loadWithSeed<RoadEvent[]>('event', getRoadToDevconEvents, ROAD_TO_DEVCON_EVENTS),
+    loadWithSeed<RoadCommunity[]>('communities', getRoadToDevconCommunities, ROAD_TO_DEVCON_COMMUNITIES),
+  ])
+  return { props: { events, communities, messages }, revalidate: 1800 }
 }

--- a/devcon/src/services/nocodb.ts
+++ b/devcon/src/services/nocodb.ts
@@ -108,3 +108,33 @@ export async function listRows(viewId: string, opts: { sort?: string } = {}): Pr
   }
   return out
 }
+
+/**
+ * List every row of a table by its table id via the v2 records API — no view
+ * or meta lookups needed (unlike `listViewRows`). Paginates to a cap.
+ * Read-only; safe for public listings.
+ */
+export async function listTableRows(
+  tableId: string,
+  opts: { pageSize?: number; maxRows?: number } = {}
+): Promise<Record<string, any>[]> {
+  if (!NOCODB_BASE_URL || !NOCODB_API_TOKEN) {
+    throw new Error('NocoDB env vars not configured (NOCODB_BASE_URL, NOCODB_API_TOKEN)')
+  }
+  const pageSize = opts.pageSize ?? 100
+  const maxRows = opts.maxRows ?? 500
+  const rows: Record<string, any>[] = []
+  let offset = 0
+  while (rows.length < maxRows) {
+    const url = `${NOCODB_BASE_URL}/api/v2/tables/${tableId}/records?limit=${pageSize}&offset=${offset}`
+    const res = await fetch(url, { headers: { 'xc-token': NOCODB_API_TOKEN } })
+    if (!res.ok) throw new Error(`NocoDB list records for ${tableId} failed: HTTP ${res.status}`)
+    const json = (await res.json()) as { list?: Record<string, any>[]; pageInfo?: { isLastPage?: boolean } }
+    const page = json.list ?? []
+    rows.push(...page)
+    const isLast = json.pageInfo?.isLastPage ?? page.length < pageSize
+    if (isLast) break
+    offset += pageSize
+  }
+  return rows
+}

--- a/devcon/src/services/nocodb.ts
+++ b/devcon/src/services/nocodb.ts
@@ -34,29 +34,50 @@ export async function createRow(viewId: string, data: Record<string, any>) {
   return api.dbTableRow.create('noco', baseId, tableId, data)
 }
 
+interface PageOpts {
+  pageSize?: number
+  maxRows?: number
+}
+interface PageResult<T> {
+  list?: T[]
+  pageInfo?: { isLastPage?: boolean }
+}
+
+/**
+ * Walk a paginated NocoDB list endpoint until the server says it's the last
+ * page, a short/empty page comes back, or the row cap is reached. The offset
+ * advances by rows actually received: NocoDB clamps `limit` to its own
+ * maximum (100 by default), so trusting the requested page size would skip rows.
+ */
+async function paginate<T>(
+  fetchPage: (limit: number, offset: number) => Promise<PageResult<T>>,
+  opts: PageOpts = {}
+): Promise<T[]> {
+  const pageSize = opts.pageSize ?? 100
+  const maxRows = opts.maxRows ?? 500
+  const rows: T[] = []
+  let offset = 0
+  while (rows.length < maxRows) {
+    const result = await fetchPage(pageSize, offset)
+    const page = result?.list ?? []
+    rows.push(...page)
+    if (page.length === 0 || page.length < pageSize || result?.pageInfo?.isLastPage) break
+    offset += page.length
+  }
+  return rows
+}
+
 /**
  * List rows of the table backing a form view. Paginates through all records
  * (capped) so callers get the full set. Read-only; safe for public listings.
  */
-export async function listViewRows(
-  viewId: string,
-  opts: { pageSize?: number; maxRows?: number } = {}
-): Promise<any[]> {
+export async function listViewRows(viewId: string, opts: PageOpts = {}): Promise<any[]> {
   const { baseId, tableId } = await resolveViewTable(viewId)
   const api = getApi()
-  const pageSize = opts.pageSize ?? 100
-  const maxRows = opts.maxRows ?? 500
-  const rows: any[] = []
-  let offset = 0
-  while (rows.length < maxRows) {
-    const result = await api.dbTableRow.list('noco', baseId, tableId, { limit: pageSize, offset })
-    const page = (result as any)?.list ?? []
-    rows.push(...page)
-    const isLast = (result as any)?.pageInfo?.isLastPage ?? page.length < pageSize
-    if (isLast) break
-    offset += pageSize
-  }
-  return rows
+  return paginate<any>(
+    (limit, offset) => api.dbTableRow.list('noco', baseId, tableId, { limit, offset }) as Promise<PageResult<any>>,
+    opts
+  )
 }
 
 export async function findRowByEmail(viewId: string, emailColumn: string, email: string): Promise<any | null> {
@@ -114,27 +135,14 @@ export async function listRows(viewId: string, opts: { sort?: string } = {}): Pr
  * or meta lookups needed (unlike `listViewRows`). Paginates to a cap.
  * Read-only; safe for public listings.
  */
-export async function listTableRows(
-  tableId: string,
-  opts: { pageSize?: number; maxRows?: number } = {}
-): Promise<Record<string, any>[]> {
+export async function listTableRows(tableId: string, opts: PageOpts = {}): Promise<Record<string, any>[]> {
   if (!NOCODB_BASE_URL || !NOCODB_API_TOKEN) {
     throw new Error('NocoDB env vars not configured (NOCODB_BASE_URL, NOCODB_API_TOKEN)')
   }
-  const pageSize = opts.pageSize ?? 100
-  const maxRows = opts.maxRows ?? 500
-  const rows: Record<string, any>[] = []
-  let offset = 0
-  while (rows.length < maxRows) {
-    const url = `${NOCODB_BASE_URL}/api/v2/tables/${tableId}/records?limit=${pageSize}&offset=${offset}`
+  return paginate<Record<string, any>>(async (limit, offset) => {
+    const url = `${NOCODB_BASE_URL}/api/v2/tables/${tableId}/records?limit=${limit}&offset=${offset}`
     const res = await fetch(url, { headers: { 'xc-token': NOCODB_API_TOKEN } })
     if (!res.ok) throw new Error(`NocoDB list records for ${tableId} failed: HTTP ${res.status}`)
-    const json = (await res.json()) as { list?: Record<string, any>[]; pageInfo?: { isLastPage?: boolean } }
-    const page = json.list ?? []
-    rows.push(...page)
-    const isLast = json.pageInfo?.isLastPage ?? page.length < pageSize
-    if (isLast) break
-    offset += pageSize
-  }
-  return rows
+    return res.json() as Promise<PageResult<Record<string, any>>>
+  }, opts)
 }

--- a/devcon/src/services/rtd-communities.ts
+++ b/devcon/src/services/rtd-communities.ts
@@ -7,7 +7,7 @@
  */
 import { listTableRows } from './nocodb'
 import { ensurePublicCommunityLogo, type NocoAttachment } from './rtd-event-images'
-import { firstImageAttachment, isChecked, pick, proxyImageUrl } from './rtd-events'
+import { firstImageAttachment, isChecked, pick, proxyImageUrl, safeHttpUrl } from './rtd-events'
 import type { RoadCommunity } from 'components/domain/road-to-devcon/communities'
 
 const RTD_COMMUNITIES_LOGOS_TABLE_ID = 'mmxfm3qbk5sqb8u'
@@ -21,11 +21,30 @@ const FIELDS = {
   featured: ['Featured', 'Published', 'Visible'],
 } as const
 
+/** A Featured row with the fields we need, before its logo has been mirrored. */
+interface Candidate extends Omit<RoadCommunity, 'logo'> {
+  rowId: string | number
+  att: NocoAttachment
+}
+
+/**
+ * Mirror the logo into Supabase Storage (no-op after the first time) so it
+ * gets a stable public URL. A failed mirror falls back to the uncacheable
+ * proxy URL rather than dropping the logo; null means nothing servable.
+ */
+async function resolveLogoUrl({ rowId, att }: Candidate): Promise<string | null> {
+  try {
+    return (await ensurePublicCommunityLogo(rowId, att)) ?? proxyImageUrl(att) ?? null
+  } catch (e) {
+    console.warn(`[rtd-communities] logo mirror failed for row ${rowId}, using proxy:`, (e as Error).message)
+    return proxyImageUrl(att) ?? null
+  }
+}
+
 export async function getRoadToDevconCommunities(): Promise<RoadCommunity[]> {
   const rows = await listTableRows(RTD_COMMUNITIES_LOGOS_TABLE_ID)
 
-  const communities: RoadCommunity[] = []
-  const logos: Array<{ community: RoadCommunity; rowId: string | number; att: NocoAttachment }> = []
+  const candidates: Candidate[] = []
   for (const row of rows) {
     // Fail-closed: only rows explicitly flagged Featured make it onto the page.
     if (!isChecked(pick(row, FIELDS.featured))) continue
@@ -36,32 +55,21 @@ export async function getRoadToDevconCommunities(): Promise<RoadCommunity[]> {
     if (!name || !att) continue
 
     const rowId = row.Id ?? row.id ?? String(name)
-    const rawUrl = pick(row, FIELDS.url)
-    const community: RoadCommunity = {
+    candidates.push({
       id: `nocodb-${rowId}`,
       name: String(name),
-      logo: '',
       // null, not undefined — getStaticProps serializes null but throws on undefined.
-      url: rawUrl ? String(rawUrl) : null,
-    }
-    communities.push(community)
-    logos.push({ community, rowId, att })
+      url: safeHttpUrl(pick(row, FIELDS.url)),
+      rowId,
+      att,
+    })
   }
 
-  // Mirror attachments into Supabase Storage (no-op after the first time) so
-  // logos get stable public URLs. A failed mirror falls back to the uncacheable
-  // proxy URL rather than dropping the logo.
-  await Promise.all(
-    logos.map(async ({ community, rowId, att }) => {
-      try {
-        community.logo = (await ensurePublicCommunityLogo(rowId, att)) ?? proxyImageUrl(att) ?? ''
-      } catch (e) {
-        console.warn(`[rtd-communities] logo mirror failed for row ${rowId}, using proxy:`, (e as Error).message)
-        community.logo = proxyImageUrl(att) ?? ''
-      }
+  const resolved = await Promise.all(
+    candidates.map(async (c): Promise<RoadCommunity | null> => {
+      const logo = await resolveLogoUrl(c)
+      return logo ? { id: c.id, name: c.name, logo, url: c.url } : null
     })
   )
-
-  // Drop anything that ended up with no servable logo URL at all.
-  return communities.filter(c => c.logo)
+  return resolved.filter((c): c is RoadCommunity => c !== null)
 }

--- a/devcon/src/services/rtd-communities.ts
+++ b/devcon/src/services/rtd-communities.ts
@@ -1,0 +1,67 @@
+/**
+ * Road to Devcon community co-creators, sourced from the NocoDB
+ * "RTD Communities Logos" table in the Road to Devcon base.
+ *
+ * Server-only: relies on NOCODB_BASE_URL + NOCODB_API_TOKEN (and Supabase
+ * credentials for logo mirroring). Call from getStaticProps, never the browser.
+ */
+import { listTableRows } from './nocodb'
+import { ensurePublicCommunityLogo, type NocoAttachment } from './rtd-event-images'
+import { firstImageAttachment, isChecked, pick, proxyImageUrl } from './rtd-events'
+import type { RoadCommunity } from 'components/domain/road-to-devcon/communities'
+
+const RTD_COMMUNITIES_LOGOS_TABLE_ID = 'mmxfm3qbk5sqb8u'
+
+// NocoDB column titles → our fields. The first matching, non-empty column
+// wins; extra fallbacks tolerate renames.
+const FIELDS = {
+  name: ['Name', 'Title', 'Community'],
+  logo: ['Logo', 'Image'],
+  url: ['Link', 'URL', 'Website'],
+  featured: ['Featured', 'Published', 'Visible'],
+} as const
+
+export async function getRoadToDevconCommunities(): Promise<RoadCommunity[]> {
+  const rows = await listTableRows(RTD_COMMUNITIES_LOGOS_TABLE_ID)
+
+  const communities: RoadCommunity[] = []
+  const logos: Array<{ community: RoadCommunity; rowId: string | number; att: NocoAttachment }> = []
+  for (const row of rows) {
+    // Fail-closed: only rows explicitly flagged Featured make it onto the page.
+    if (!isChecked(pick(row, FIELDS.featured))) continue
+
+    const name = pick(row, FIELDS.name)
+    const att = firstImageAttachment(pick(row, FIELDS.logo))
+    // A logo wall entry needs both a name (alt text) and an image.
+    if (!name || !att) continue
+
+    const rowId = row.Id ?? row.id ?? String(name)
+    const rawUrl = pick(row, FIELDS.url)
+    const community: RoadCommunity = {
+      id: `nocodb-${rowId}`,
+      name: String(name),
+      logo: '',
+      // null, not undefined — getStaticProps serializes null but throws on undefined.
+      url: rawUrl ? String(rawUrl) : null,
+    }
+    communities.push(community)
+    logos.push({ community, rowId, att })
+  }
+
+  // Mirror attachments into Supabase Storage (no-op after the first time) so
+  // logos get stable public URLs. A failed mirror falls back to the uncacheable
+  // proxy URL rather than dropping the logo.
+  await Promise.all(
+    logos.map(async ({ community, rowId, att }) => {
+      try {
+        community.logo = (await ensurePublicCommunityLogo(rowId, att)) ?? proxyImageUrl(att) ?? ''
+      } catch (e) {
+        console.warn(`[rtd-communities] logo mirror failed for row ${rowId}, using proxy:`, (e as Error).message)
+        community.logo = proxyImageUrl(att) ?? ''
+      }
+    })
+  )
+
+  // Drop anything that ended up with no servable logo URL at all.
+  return communities.filter(c => c.logo)
+}

--- a/devcon/src/services/rtd-event-images.ts
+++ b/devcon/src/services/rtd-event-images.ts
@@ -1,5 +1,5 @@
 /**
- * Mirrors NocoDB attachment images into a public Supabase Storage bucket so
+ * Mirrors NocoDB attachment images (event cards, community logos) into a public Supabase Storage bucket so
  * public pages serve stable, CDN-cacheable URLs instead of proxying NocoDB's
  * short-lived signed `/dltemp/` URLs through `/api/nocodb/file` on every view.
  *
@@ -13,13 +13,31 @@
 import { createClient, SupabaseClient } from '@supabase/supabase-js'
 
 const BUCKET = 'rtd-event-images'
-const FOLDER = 'rtd-events'
 
-// Card display size: ~430px wide at the 3-column breakpoint, 2x for retina.
-// Generated once per attachment at mirror time so the page never depends on
-// a per-request image optimizer (whose cache Netlify purges on every deploy).
-const CARD_WIDTH = 860
-const CARD_QUALITY = 80
+// Variants are generated once per attachment at mirror time so the page never
+// depends on a per-request image optimizer (whose cache Netlify purges on
+// every deploy).
+const WEBP_QUALITY = 80
+
+/** Where in the bucket a mirrored image lives and which resized variant to serve. */
+interface MirrorOptions {
+  /** Bucket folder, e.g. 'rtd-events'. */
+  folder: string
+  /** Resized WebP variant to generate and serve; null serves the original. */
+  variant: { suffix: string; resize: { width?: number; height?: number } } | null
+  /** Accept SVG attachments (served as the original, never resized). Off by default. */
+  allowSvg?: boolean
+}
+
+// Event cards: ~430px wide at the 3-column breakpoint, 2x for retina.
+const EVENT_CARD: MirrorOptions = { folder: 'rtd-events', variant: { suffix: '-card', resize: { width: 860 } } }
+// Community logos: rendered at h-14 (56px), 2x for retina. Wordmarks are often
+// SVG, which we keep as-is so they stay crisp.
+const COMMUNITY_LOGO: MirrorOptions = {
+  folder: 'rtd-communities',
+  variant: { suffix: '-logo', resize: { height: 112 } },
+  allowSvg: true,
+}
 
 /** The slice of a NocoDB attachment cell entry we rely on. */
 export interface NocoAttachment {
@@ -37,6 +55,7 @@ const EXT_BY_MIME: Record<string, string> = {
   'image/webp': 'webp',
   'image/gif': 'gif',
 }
+const SVG_MIME = 'image/svg+xml'
 
 let client: SupabaseClient | null = null
 function getSupabase(): SupabaseClient {
@@ -51,15 +70,23 @@ function getSupabase(): SupabaseClient {
   return client
 }
 
-function storageKeys(rowId: string | number, att: NocoAttachment): { original: string; card: string } | null {
-  const ext = EXT_BY_MIME[String(att.mimetype ?? '').toLowerCase()]
+function storageKeys(
+  rowId: string | number,
+  att: NocoAttachment,
+  opts: MirrorOptions
+): { original: string; variant: string | null } | null {
+  const mime = String(att.mimetype ?? '').toLowerCase()
+  const isSvg = mime === SVG_MIME
+  const ext = isSvg ? (opts.allowSvg ? 'svg' : undefined) : EXT_BY_MIME[mime]
   if (!ext) return null
   // Attachment ids are stable per uploaded file; fall back to title+size so a
   // pre-id NocoDB row still gets a deterministic (if weaker) identity.
   const attId = att.id ?? `${att.title ?? 'file'}-${att.size ?? 0}`
   const safe = String(attId).replace(/[^a-zA-Z0-9._-]/g, '_')
-  const base = `${FOLDER}/${rowId}-${safe}`
-  return { original: `${base}.${ext}`, card: `${base}-card.webp` }
+  const base = `${opts.folder}/${rowId}-${safe}`
+  // SVGs are never rasterized — the original is the served file.
+  const variant = opts.variant && !isSvg ? `${base}${opts.variant.suffix}.webp` : null
+  return { original: `${base}.${ext}`, variant }
 }
 
 function downloadUrl(att: NocoAttachment): string | null {
@@ -95,45 +122,61 @@ async function download(att: NocoAttachment): Promise<Buffer> {
   return Buffer.from(await res.arrayBuffer())
 }
 
-/** Resize/re-encode to the card-sized WebP variant served on the public page. */
-async function toCardWebp(original: Buffer): Promise<Buffer> {
+/** Resize/re-encode to the WebP variant served on the public page. */
+async function toWebpVariant(original: Buffer, resize: { width?: number; height?: number }): Promise<Buffer> {
   // Dynamic import: sharp is a native module only needed at build/revalidate.
   const sharp = (await import('sharp')).default
   return sharp(original, { animated: true })
-    .resize({ width: CARD_WIDTH, withoutEnlargement: true })
-    .webp({ quality: CARD_QUALITY })
+    .resize({ ...resize, withoutEnlargement: true })
+    .webp({ quality: WEBP_QUALITY })
     .toBuffer()
 }
 
 /**
  * Ensure the attachment is mirrored into the public bucket and return the
- * stable public URL of its card-sized WebP variant (or the original if the
- * variant can't be generated). Downloads from NocoDB and resizes at most once
- * per attachment; on every later call the existence check short-circuits.
- * Returns null for attachments we can't mirror (unknown mime type); throws on
- * transport errors so callers can fall back.
+ * stable public URL of its resized WebP variant (or the original if there is
+ * no variant, or it can't be generated). Downloads from NocoDB and resizes at
+ * most once per attachment; on every later call the existence check
+ * short-circuits. Returns null for attachments we can't mirror (unknown mime
+ * type); throws on transport errors so callers can fall back.
  */
-export async function ensurePublicEventImage(rowId: string | number, att: NocoAttachment): Promise<string | null> {
-  const keys = storageKeys(rowId, att)
+async function ensurePublicImage(
+  rowId: string | number,
+  att: NocoAttachment,
+  opts: MirrorOptions
+): Promise<string | null> {
+  const keys = storageKeys(rowId, att, opts)
   if (!keys) return null
 
   const supabase = getSupabase()
   const publicUrl = (key: string) => supabase.storage.from(BUCKET).getPublicUrl(key).data.publicUrl
 
-  const { data: cardExists } = await supabase.storage.from(BUCKET).exists(keys.card)
-  if (cardExists) return publicUrl(keys.card)
+  const served = keys.variant ?? keys.original
+  const { data: servedExists } = await supabase.storage.from(BUCKET).exists(served)
+  if (servedExists) return publicUrl(served)
 
   const original = await download(att)
-  // Keep the full-size original alongside the card variant (e.g. for future
-  // OG images, or regenerating variants at a different size).
+  // Keep the full-size original alongside the variant (e.g. for future OG
+  // images, or regenerating variants at a different size).
   const { data: originalExists } = await supabase.storage.from(BUCKET).exists(keys.original)
   if (!originalExists) await upload(supabase, keys.original, original, att.mimetype)
+  if (!keys.variant || !opts.variant) return publicUrl(keys.original)
 
   try {
-    await upload(supabase, keys.card, await toCardWebp(original), 'image/webp')
+    await upload(supabase, keys.variant, await toWebpVariant(original, opts.variant.resize), 'image/webp')
   } catch (e) {
-    console.warn(`[rtd-event-images] card variant failed for ${keys.card}, serving original:`, (e as Error).message)
+    console.warn(`[rtd-event-images] variant failed for ${keys.variant}, serving original:`, (e as Error).message)
     return publicUrl(keys.original)
   }
-  return publicUrl(keys.card)
+  return publicUrl(keys.variant)
+}
+
+/** Event card image: 860px-wide WebP under `rtd-events/`. */
+export function ensurePublicEventImage(rowId: string | number, att: NocoAttachment): Promise<string | null> {
+  return ensurePublicImage(rowId, att, EVENT_CARD)
+}
+
+/** Community logo: 112px-tall WebP under `rtd-communities/` (SVGs served as-is). */
+export function ensurePublicCommunityLogo(rowId: string | number, att: NocoAttachment): Promise<string | null> {
+  return ensurePublicImage(rowId, att, COMMUNITY_LOGO)
 }

--- a/devcon/src/services/rtd-event-images.ts
+++ b/devcon/src/services/rtd-event-images.ts
@@ -140,10 +140,13 @@ async function toWebpVariant(
 ): Promise<Buffer> {
   // Dynamic import: sharp is a native module only needed at build/revalidate.
   const sharp = (await import('sharp')).default
-  return sharp(original, isSvg ? { density: SVG_RASTER_DENSITY } : { animated: true })
-    .resize({ ...resize, withoutEnlargement: true })
-    .webp({ quality: WEBP_QUALITY })
-    .toBuffer()
+  return (
+    sharp(original, isSvg ? { density: SVG_RASTER_DENSITY } : { animated: true })
+      // Never upscale rasters; an SVG has no intrinsic pixel size so it may scale to the target.
+      .resize({ ...resize, withoutEnlargement: !isSvg })
+      .webp({ quality: WEBP_QUALITY })
+      .toBuffer()
+  )
 }
 
 /**

--- a/devcon/src/services/rtd-event-images.ts
+++ b/devcon/src/services/rtd-event-images.ts
@@ -23,20 +23,24 @@ const WEBP_QUALITY = 80
 interface MirrorOptions {
   /** Bucket folder, e.g. 'rtd-events'. */
   folder: string
-  /** Resized WebP variant to generate and serve; null serves the original. */
-  variant: { suffix: string; resize: { width?: number; height?: number } } | null
-  /** Accept SVG attachments (served as the original, never resized). Off by default. */
-  allowSvg?: boolean
+  /** Resized WebP variant to generate and serve. */
+  variant: { suffix: string; resize: { width?: number; height?: number } }
+  /**
+   * Also accept SVG attachments. They are rasterized into the WebP variant and
+   * never stored or served as SVG — an SVG opened directly (rather than via
+   * <img>) can run script on the bucket's origin. Off by default.
+   */
+  acceptSvg?: boolean
 }
 
 // Event cards: ~430px wide at the 3-column breakpoint, 2x for retina.
 const EVENT_CARD: MirrorOptions = { folder: 'rtd-events', variant: { suffix: '-card', resize: { width: 860 } } }
 // Community logos: rendered at h-14 (56px), 2x for retina. Wordmarks are often
-// SVG, which we keep as-is so they stay crisp.
+// uploaded as SVG, so accept (and rasterize) those too.
 const COMMUNITY_LOGO: MirrorOptions = {
   folder: 'rtd-communities',
   variant: { suffix: '-logo', resize: { height: 112 } },
-  allowSvg: true,
+  acceptSvg: true,
 }
 
 /** The slice of a NocoDB attachment cell entry we rely on. */
@@ -56,6 +60,9 @@ const EXT_BY_MIME: Record<string, string> = {
   'image/gif': 'gif',
 }
 const SVG_MIME = 'image/svg+xml'
+// SVGs have no intrinsic pixel size; render at a high density so a nominally
+// small logo still downsizes cleanly to the variant instead of being upscaled.
+const SVG_RASTER_DENSITY = 300
 
 let client: SupabaseClient | null = null
 function getSupabase(): SupabaseClient {
@@ -70,23 +77,26 @@ function getSupabase(): SupabaseClient {
   return client
 }
 
+/**
+ * Bucket keys for an attachment: the served WebP variant, plus the full-size
+ * original (kept for future variants; null for SVG, which is never stored).
+ * Returns null for mime types we don't mirror.
+ */
 function storageKeys(
   rowId: string | number,
   att: NocoAttachment,
   opts: MirrorOptions
-): { original: string; variant: string | null } | null {
+): { original: string | null; variant: string; isSvg: boolean } | null {
   const mime = String(att.mimetype ?? '').toLowerCase()
   const isSvg = mime === SVG_MIME
-  const ext = isSvg ? (opts.allowSvg ? 'svg' : undefined) : EXT_BY_MIME[mime]
+  const ext = isSvg ? (opts.acceptSvg ? 'svg' : undefined) : EXT_BY_MIME[mime]
   if (!ext) return null
   // Attachment ids are stable per uploaded file; fall back to title+size so a
   // pre-id NocoDB row still gets a deterministic (if weaker) identity.
   const attId = att.id ?? `${att.title ?? 'file'}-${att.size ?? 0}`
   const safe = String(attId).replace(/[^a-zA-Z0-9._-]/g, '_')
   const base = `${opts.folder}/${rowId}-${safe}`
-  // SVGs are never rasterized — the original is the served file.
-  const variant = opts.variant && !isSvg ? `${base}${opts.variant.suffix}.webp` : null
-  return { original: `${base}.${ext}`, variant }
+  return { original: isSvg ? null : `${base}.${ext}`, variant: `${base}${opts.variant.suffix}.webp`, isSvg }
 }
 
 function downloadUrl(att: NocoAttachment): string | null {
@@ -123,10 +133,14 @@ async function download(att: NocoAttachment): Promise<Buffer> {
 }
 
 /** Resize/re-encode to the WebP variant served on the public page. */
-async function toWebpVariant(original: Buffer, resize: { width?: number; height?: number }): Promise<Buffer> {
+async function toWebpVariant(
+  original: Buffer,
+  resize: { width?: number; height?: number },
+  isSvg: boolean
+): Promise<Buffer> {
   // Dynamic import: sharp is a native module only needed at build/revalidate.
   const sharp = (await import('sharp')).default
-  return sharp(original, { animated: true })
+  return sharp(original, isSvg ? { density: SVG_RASTER_DENSITY } : { animated: true })
     .resize({ ...resize, withoutEnlargement: true })
     .webp({ quality: WEBP_QUALITY })
     .toBuffer()
@@ -134,11 +148,11 @@ async function toWebpVariant(original: Buffer, resize: { width?: number; height?
 
 /**
  * Ensure the attachment is mirrored into the public bucket and return the
- * stable public URL of its resized WebP variant (or the original if there is
- * no variant, or it can't be generated). Downloads from NocoDB and resizes at
- * most once per attachment; on every later call the existence check
- * short-circuits. Returns null for attachments we can't mirror (unknown mime
- * type); throws on transport errors so callers can fall back.
+ * stable public URL of its resized WebP variant (or the original if the
+ * variant can't be generated). Downloads from NocoDB and resizes at most once
+ * per attachment; on every later call the existence check short-circuits.
+ * Returns null for attachments we can't mirror (unknown mime type); throws on
+ * transport errors so callers can fall back.
  */
 async function ensurePublicImage(
   rowId: string | number,
@@ -151,20 +165,22 @@ async function ensurePublicImage(
   const supabase = getSupabase()
   const publicUrl = (key: string) => supabase.storage.from(BUCKET).getPublicUrl(key).data.publicUrl
 
-  const served = keys.variant ?? keys.original
-  const { data: servedExists } = await supabase.storage.from(BUCKET).exists(served)
-  if (servedExists) return publicUrl(served)
+  const { data: variantExists } = await supabase.storage.from(BUCKET).exists(keys.variant)
+  if (variantExists) return publicUrl(keys.variant)
 
   const original = await download(att)
   // Keep the full-size original alongside the variant (e.g. for future OG
   // images, or regenerating variants at a different size).
-  const { data: originalExists } = await supabase.storage.from(BUCKET).exists(keys.original)
-  if (!originalExists) await upload(supabase, keys.original, original, att.mimetype)
-  if (!keys.variant || !opts.variant) return publicUrl(keys.original)
+  if (keys.original) {
+    const { data: originalExists } = await supabase.storage.from(BUCKET).exists(keys.original)
+    if (!originalExists) await upload(supabase, keys.original, original, att.mimetype)
+  }
 
   try {
-    await upload(supabase, keys.variant, await toWebpVariant(original, opts.variant.resize), 'image/webp')
+    await upload(supabase, keys.variant, await toWebpVariant(original, opts.variant.resize, keys.isSvg), 'image/webp')
   } catch (e) {
+    // No stored original to fall back to for SVG — rethrow so the caller uses its own fallback.
+    if (!keys.original) throw e
     console.warn(`[rtd-event-images] variant failed for ${keys.variant}, serving original:`, (e as Error).message)
     return publicUrl(keys.original)
   }
@@ -176,7 +192,7 @@ export function ensurePublicEventImage(rowId: string | number, att: NocoAttachme
   return ensurePublicImage(rowId, att, EVENT_CARD)
 }
 
-/** Community logo: 112px-tall WebP under `rtd-communities/` (SVGs served as-is). */
+/** Community logo: 112px-tall WebP under `rtd-communities/` (SVG input rasterized). */
 export function ensurePublicCommunityLogo(rowId: string | number, att: NocoAttachment): Promise<string | null> {
   return ensurePublicImage(rowId, att, COMMUNITY_LOGO)
 }

--- a/devcon/src/services/rtd-events.ts
+++ b/devcon/src/services/rtd-events.ts
@@ -29,14 +29,14 @@ const FIELDS = {
 } as const
 
 /** Interpret a NocoDB checkbox/boolean cell as true. */
-function isChecked(v: any): boolean {
+export function isChecked(v: any): boolean {
   if (v === true) return true
   if (typeof v === 'number') return v !== 0
   if (typeof v === 'string') return ['true', '1', 'yes', 'checked'].includes(v.trim().toLowerCase())
   return false
 }
 
-function pick(row: Record<string, any>, keys: readonly string[]): any {
+export function pick(row: Record<string, any>, keys: readonly string[]): any {
   for (const k of keys) {
     const v = row[k]
     if (v !== undefined && v !== null && v !== '') return v
@@ -45,7 +45,7 @@ function pick(row: Record<string, any>, keys: readonly string[]): any {
 }
 
 /** Parse a NocoDB attachment cell and return its first image attachment, if any. */
-function firstImageAttachment(value: any): NocoAttachment | undefined {
+export function firstImageAttachment(value: any): NocoAttachment | undefined {
   let arr = value
   if (typeof value === 'string') {
     try {
@@ -64,7 +64,7 @@ function firstImageAttachment(value: any): NocoAttachment | undefined {
  * Fallback image URL through the `/api/nocodb/file` proxy (short-lived signed
  * URL, uncacheable — only used when mirroring to Supabase Storage fails).
  */
-function proxyImageUrl(a: NocoAttachment): string | undefined {
+export function proxyImageUrl(a: NocoAttachment): string | undefined {
   const name = a?.title ? `&filename=${encodeURIComponent(a.title)}` : ''
   if (a?.signedUrl) return `/api/nocodb/file/?url=${encodeURIComponent(a.signedUrl)}${name}`
   if (a?.signedPath) return `/api/nocodb/file/?path=${encodeURIComponent(a.signedPath)}${name}`

--- a/devcon/src/services/rtd-events.ts
+++ b/devcon/src/services/rtd-events.ts
@@ -44,6 +44,24 @@ export function pick(row: Record<string, any>, keys: readonly string[]): any {
   return undefined
 }
 
+/**
+ * Keep only http(s) links. A NocoDB URL cell written via the API (not the UI)
+ * can hold any string, and a `javascript:` value would otherwise end up in an
+ * href on the public page.
+ */
+export function safeHttpUrl(value: unknown): string | null {
+  if (!value) return null
+  let s = String(value).trim()
+  // Editors often paste a bare domain ("ethmumbai.in"); treat it as https.
+  if (/^[\w.-]+\.[a-z]{2,}(\/|$)/i.test(s)) s = `https://${s}`
+  try {
+    const u = new URL(s)
+    return u.protocol === 'http:' || u.protocol === 'https:' ? u.toString() : null
+  } catch {
+    return null
+  }
+}
+
 /** Parse a NocoDB attachment cell and return its first image attachment, if any. */
 export function firstImageAttachment(value: any): NocoAttachment | undefined {
   let arr = value
@@ -150,7 +168,7 @@ export async function getRoadToDevconEvents(): Promise<RoadEvent[]> {
       date,
       types,
       // null, not undefined — getStaticProps serializes null but throws on undefined.
-      url: rawUrl ? String(rawUrl) : null,
+      url: safeHttpUrl(rawUrl),
       image: null,
       gradient: gradientFor(id),
     }

--- a/devcon/src/utils/shuffle.ts
+++ b/devcon/src/utils/shuffle.ts
@@ -1,0 +1,9 @@
+/** Fisher–Yates shuffle. Returns a new array; the input is left untouched. */
+export function shuffle<T>(items: readonly T[]): T[] {
+  const out = [...items]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}


### PR DESCRIPTION
- Adds a redesigned RTD Communities section, powered by data from a new NocoDB table.
- This allows Ecosystem team to add community logos and details without technical intervention.
- The community logo asset is converted to .webp, with their link applied to `/road-to-devcon` and displayed randomly (browser-based, runtime)
- If logos exceed 10, a 'Load more' SecondaryCTA is shown to load the remaining logos.

More details in individual commits.