### PR TITLE
which ticket is yours, interests sync, swag pickup state

### DIFF
--- a/devcon-api/src/supabase/migrations/20260909120000_devcon8_ticket_links.sql
+++ b/devcon-api/src/supabase/migrations/20260909120000_devcon8_ticket_links.sql
@@ -1,0 +1,21 @@
+-- Tickets an event-app account has proven it holds, by uploading the ticket's
+-- QR code or by choosing one of the tickets already under its email.
+-- One row per (account, event, Pretix order position). The QR payload itself is
+-- never stored: secret_hash is a SHA-256 of it, enough to recognise a code that
+-- was already attached. Only the service-role key touches this table; RLS with
+-- no policies keeps the anon key out.
+
+create table if not exists devcon8_ticket_links (
+  user_id uuid not null,
+  -- Pretix event slug the position belongs to (the app is configured per event).
+  event text not null,
+  position_id bigint not null,
+  secret_hash text not null,
+  attached_at timestamptz not null default now(),
+  primary key (user_id, event, position_id)
+);
+
+create index if not exists devcon8_ticket_links_position_idx
+  on devcon8_ticket_links (event, position_id);
+
+alter table devcon8_ticket_links enable row level security;

--- a/devcon-api/src/supabase/migrations/20260909130000_devcon8_interests.sql
+++ b/devcon-api/src/supabase/migrations/20260909130000_devcon8_interests.sql
@@ -1,0 +1,76 @@
+-- "Interested" stars synced to the event-app account. The device (Dexie)
+-- stays the source of truth; this table is the meeting point between
+-- a user's devices. One row per (account, event, kind, item), kept as a
+-- tombstone (interested = false) when unstarred so the removal wins elsewhere.
+--
+-- updated_at is the device's change time in ms and decides conflicts (last
+-- write wins per item). synced_at is the server's write time and is the sync
+-- cursor, so a device with a wrong clock never misses another device's change.
+-- Only the service-role key touches this table; RLS with no policies keeps the
+-- anon key out.
+
+create table if not exists devcon8_interests (
+  user_id uuid not null,
+  event text not null,
+  kind text not null check (kind in ('session', 'speaker')),
+  item_id text not null,
+  interested boolean not null,
+  updated_at bigint not null,
+  synced_at timestamptz not null,
+  primary key (user_id, event, kind, item_id)
+);
+
+create index if not exists devcon8_interests_cursor_idx
+  on devcon8_interests (user_id, event, synced_at);
+
+alter table devcon8_interests enable row level security;
+
+-- Merge a device's pending changes (last write wins per item), then return
+-- every row of the account for this event written since p_since (all rows
+-- when null) together with the server clock to use as the next cursor.
+create or replace function devcon8_interests_sync(
+  p_user_id uuid,
+  p_event text,
+  p_since timestamptz,
+  p_changes jsonb
+) returns jsonb
+language plpgsql
+as $$
+declare
+  v_now timestamptz := clock_timestamp();
+  v_rows jsonb;
+begin
+  insert into devcon8_interests (user_id, event, kind, item_id, interested, updated_at, synced_at)
+  select p_user_id, p_event, c.kind, c.item_id, c.interested, c.updated_at, v_now
+  from jsonb_to_recordset(coalesce(p_changes, '[]'::jsonb))
+    as c(kind text, item_id text, interested boolean, updated_at bigint)
+  on conflict (user_id, event, kind, item_id) do update
+    set interested = excluded.interested,
+        updated_at = excluded.updated_at,
+        synced_at = v_now
+    where excluded.updated_at > devcon8_interests.updated_at;
+
+  select coalesce(
+    jsonb_agg(jsonb_build_object(
+      'kind', r.kind,
+      'id', r.item_id,
+      'interested', r.interested,
+      'updatedAt', r.updated_at
+    )),
+    '[]'::jsonb
+  )
+  into v_rows
+  from devcon8_interests r
+  where r.user_id = p_user_id
+    and r.event = p_event
+    and (p_since is null or r.synced_at > p_since);
+
+  return jsonb_build_object(
+    'changes', v_rows,
+    'now', (extract(epoch from v_now) * 1000)::bigint
+  );
+end
+$$;
+
+revoke all on function devcon8_interests_sync(uuid, text, timestamptz, jsonb) from public;
+revoke all on function devcon8_interests_sync(uuid, text, timestamptz, jsonb) from anon, authenticated;

--- a/devcon-api/src/supabase/migrations/20260910100000_devcon8_ticket_links_proof.sql
+++ b/devcon-api/src/supabase/migrations/20260910100000_devcon8_ticket_links_proof.sql
@@ -1,0 +1,10 @@
+-- Why a ticket link exists, so re-verification can check the reason still
+-- holds: 'email' when the account chose one of the tickets under its own
+-- email (the match was the proof; the link is dropped once the position's
+-- attendee email no longer matches), 'qr' when it uploaded the ticket's QR
+-- (possession stands regardless of the email). Rows created before this
+-- column default to 'qr', the treatment that keeps them.
+
+alter table devcon8_ticket_links
+  add column if not exists proof text not null default 'qr'
+  check (proof in ('email', 'qr'));

--- a/devcon/package.json
+++ b/devcon/package.json
@@ -38,6 +38,7 @@
     "pretix:export-attendee-emails": "tsx src/scripts/pretix/export-attendee-emails.ts",
     "send-early-bird-reminder": "ts-node src/scripts/send-early-bird-reminder.ts",
     "send-install-reminder": "tsx src/scripts/send-install-reminder.ts",
+    "send-attendee-email-reminder": "tsx src/scripts/send-attendee-email-reminder.ts",
     "students:bulk-validate": "ts-node src/scripts/students/bulk-validate-whitelisted.ts",
     "forms:decrypt": "tsx scripts/decrypt.ts",
     "sync:discount-data": "tsx src/scripts/sync-discount-data.ts",

--- a/devcon/src/scripts/send-attendee-email-reminder.ts
+++ b/devcon/src/scripts/send-attendee-email-reminder.ts
@@ -1,0 +1,358 @@
+/**
+ * Remind buyers who hold several Devcon 8 India tickets under their own email
+ * to give each ticket its attendee's email in Pretix.
+ *
+ * Why: the event app signs people in by email and shows the tickets carrying
+ * that email. A buyer who typed their own address on every ticket sees a pile
+ * of QR codes and has to pick theirs in the app, while their colleagues sign
+ * in and find nothing. When each ticket carries its holder's email, everyone
+ * signs in and finds their ticket already there. The app handles what is left
+ * on the day (select or QR upload); this email shrinks that case up front.
+ *
+ * Recipients (read live from Pretix, nothing to export first): buyers whose
+ * paid, non-test orders together still hold TWO OR MORE admission tickets whose
+ * attendee email is empty or equal to the order email (the same rule as the
+ * app's "Bought tickets for others?" nudge: counted across orders, since at
+ * most one of those tickets is the buyer's own). One email per buyer, listing
+ * every such order with a button straight to its "change details" form
+ * (<order url>/modify). Re-run a week later and only whoever still qualifies
+ * is picked up again.
+ *
+ * Depends on Pretix allowing customers to change attendee details: setting
+ * "Customers can modify their orders until" (last_order_modification_date)
+ * must be unset or in the future. The dry run reminds you to check.
+ *
+ * SAFE BY DEFAULT: without --send or --test-to this is a dry run. No SMTP
+ * connection is made. It prints the recipients and writes rendered .html
+ * previews to generated-codes/previews/ for review in a browser.
+ *
+ * Usage:
+ *   pnpm run send-attendee-email-reminder                                    # dry run + previews
+ *   pnpm run send-attendee-email-reminder -- --test-to you@example.com       # ONE test email to you, sample data
+ *   pnpm run send-attendee-email-reminder -- --test-to you@example.com --as buyer@example.com
+ *                                                                           # ONE test email to you with that buyer's real orders
+ *   pnpm run send-attendee-email-reminder -- --send                          # live send to every recipient
+ *   pnpm run send-attendee-email-reminder -- --send --limit 5                # live send to the first 5 only
+ *   add --skip-sent generated-codes/attendee-email-reminder-results-<ts>.csv to resume a partial run
+ *
+ * Results are written to generated-codes/attendee-email-reminder-results-<timestamp>.csv
+ * (email,orders,status) so a partial run can be resumed with --skip-sent.
+ */
+import 'dotenv/config'
+import * as fs from 'fs'
+import * as path from 'path'
+import { getTransporter, sendWithRetry, DEFAULT_FROM } from '../services/mailer'
+import { EMAIL_HEADER_ROW, EMAIL_COLOR_SCHEME_META, emailEyebrow } from '../services/emailLayout'
+import { TICKETING, TICKETING_ENV, getPretixApiToken, pretixEventUrl } from '../config/ticketing'
+
+// ---- Campaign copy ----
+const SUBJECT = '🎟️ Your Devcon 8 India tickets: who is using each one?'
+const MATOMO_PARAMS = 'mtm_campaign=attendee-email-reminder&mtm_source=email&mtm_medium=email'
+
+// ---- CLI ----
+function argValue(flag: string): string | null {
+  const i = process.argv.indexOf(flag)
+  return i !== -1 && process.argv[i + 1] ? process.argv[i + 1] : null
+}
+const doSend = process.argv.includes('--send')
+const testTo = argValue('--test-to')
+const testAs = argValue('--as')
+const skipSentPath = argValue('--skip-sent')
+const limit = argValue('--limit') ? Number(argValue('--limit')) : null
+
+// ---- Pretix (read-only; same access pattern as pretix/export-attendee-emails.ts) ----
+function normalizeBaseUrl(url: string): string {
+  let normalized = url.endsWith('/') ? url : url + '/'
+  if (!normalized.includes('/api/')) normalized = normalized + 'api/v1/'
+  return normalized
+}
+const baseUrl = normalizeBaseUrl(TICKETING.pretix.baseUrl)
+const headers: Record<string, string> = {
+  Authorization: 'Token ' + getPretixApiToken(),
+  'Content-Type': 'application/json',
+}
+const eventUrl = (endpoint: string) =>
+  baseUrl + 'organizers/' + TICKETING.pretix.organizer + '/events/' + TICKETING.pretix.event + endpoint
+
+interface PretixItem {
+  id: number
+  admission?: boolean
+}
+interface PretixPosition {
+  attendee_email: string | null
+  addon_to: number | null
+  canceled?: boolean
+  item: number
+}
+interface PretixOrder {
+  code: string
+  email: string
+  datetime: string
+  testmode?: boolean
+  url: string
+  positions: PretixPosition[]
+}
+
+async function getJson<T>(url: string): Promise<T> {
+  const res = await fetch(url, { headers })
+  if (!res.ok) throw new Error(`Pretix API error ${res.status}: ${await res.text()}`)
+  return (await res.json()) as T
+}
+
+async function fetchAdmissionItemIds(): Promise<Set<number>> {
+  const data = await getJson<{ results: PretixItem[] }>(eventUrl('/items/'))
+  // Tri-state like the app: only an explicit `admission: false` is merchandise.
+  return new Set(data.results.filter(item => item.admission !== false).map(item => item.id))
+}
+
+async function fetchPaidOrders(): Promise<PretixOrder[]> {
+  const orders: PretixOrder[] = []
+  let url: string | null = eventUrl('/orders/') + '?status=p'
+  while (url) {
+    const data: { results: PretixOrder[]; next: string | null } = await getJson(url)
+    orders.push(...data.results)
+    url = data.next
+  }
+  return orders
+}
+
+// ---- Recipient selection ----
+interface QualifyingOrder {
+  code: string
+  url: string
+  /** Order placement time, for chronological listing (same order as the app). */
+  datetime: string
+  /** Admission tickets still carrying the buyer's email (or none). */
+  ticketsWithBuyer: number
+}
+interface Recipient {
+  email: string
+  orders: QualifyingOrder[]
+}
+
+/**
+ * Buyers whose orders together hold two or more admission tickets that still
+ * carry the buyer's email (or no attendee email at all), with every order that
+ * holds at least one. Same rule as the app's buyer nudge. Pure, so it is easy
+ * to read and to check by hand against a Pretix export.
+ */
+export function selectRecipients(orders: PretixOrder[], admissionItems: Set<number>): Recipient[] {
+  const byEmail = new Map<string, Recipient>()
+  for (const order of orders) {
+    if (order.testmode) continue
+    const buyer = (order.email || '').trim().toLowerCase()
+    if (!buyer) continue
+    const ticketsWithBuyer = (order.positions ?? []).filter(
+      p =>
+        !p.addon_to &&
+        !p.canceled &&
+        admissionItems.has(p.item) &&
+        (!p.attendee_email || p.attendee_email.trim().toLowerCase() === buyer)
+    ).length
+    if (ticketsWithBuyer === 0) continue
+    const entry = byEmail.get(buyer) ?? { email: buyer, orders: [] }
+    entry.orders.push({ code: order.code, url: order.url, datetime: order.datetime, ticketsWithBuyer })
+    byEmail.set(buyer, entry)
+  }
+  return Array.from(byEmail.values())
+    .filter(r => r.orders.reduce((n, o) => n + o.ticketsWithBuyer, 0) >= 2)
+    .map(r => ({ ...r, orders: [...r.orders].sort((a, b) => a.datetime.localeCompare(b.datetime) || a.code.localeCompare(b.code)) }))
+    .sort((a, b) => a.email.localeCompare(b.email))
+}
+
+// ---- Email ----
+/** The order's "change details" form (attendee emails), straight from the button. */
+const modifyLink = (orderUrl: string) => `${orderUrl.replace(/\/?$/, '/')}modify?${MATOMO_PARAMS}`
+
+function buildReminderHtml(recipient: Recipient, testBanner = false): string {
+  const total = recipient.orders.reduce((sum, order) => sum + order.ticketsWithBuyer, 0)
+  const several = recipient.orders.length > 1
+  const intro = several
+    ? `your orders below hold <strong>${total} tickets</strong> that are all under your email.`
+    : `your order <strong>${recipient.orders[0].code}</strong> holds <strong>${total} tickets</strong> that are all under your email.`
+  const buttons = recipient.orders
+    .map(
+      order => `
+              <div style="text-align: center; margin-bottom: 12px;">
+                <a href="${modifyLink(order.url)}" style="display: inline-block; padding: 14px 32px; font-size: 16px; font-weight: 700; color: #fffffe; background-color: #7235ed; border-radius: 9999px; text-decoration: none;">
+                  ${several ? `Update order ${order.code}` : 'Update attendee emails'}
+                </a>
+              </div>`
+    )
+    .join('')
+  return `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+${EMAIL_COLOR_SCHEME_META}
+  <title>Who is using each of your Devcon 8 India tickets?</title>
+</head>
+<body style="margin: 0; padding: 0; background-color: #f5f3f7; font-family: 'Poppins', 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;">
+  <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="background-color: #f5f3f7; padding: 40px 16px;">
+    <tr>
+      <td align="center">
+        <table role="presentation" width="100%" cellpadding="0" cellspacing="0" style="max-width: 560px; background: #ffffff; border-radius: 16px; overflow: hidden; box-shadow: 0 2px 8px rgba(22, 11, 43, 0.08);">
+${EMAIL_HEADER_ROW}
+          <tr>
+            <td style="padding: 32px;">
+${emailEyebrow('Your Devcon 8 India tickets')}
+              <h2 style="margin: 0 0 16px; font-size: 20px; font-weight: 800; color: #1a0d33; text-align: center;">
+                Who is using each ticket?
+              </h2>
+              <p style="margin: 0 0 16px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                Hi, ${intro}
+              </p>
+              <p style="margin: 0 0 24px; font-size: 16px; line-height: 1.5; color: #1a0d33;">
+                Each attendee signs in to the Devcon app with the email on their ticket: that is where
+                their QR code, their schedule and their swag live. If some of these tickets are for
+                colleagues or friends, add their email to their ticket now and it will be waiting for
+                them when they sign in.
+              </p>
+${buttons}
+              <p style="margin: 12px 0 0; font-size: 14px; line-height: 1.5; color: #594d73;">
+                If every ticket is yours, there is nothing to do.
+              </p>
+            </td>
+          </tr>
+          <tr>
+            <td style="padding: 24px 32px; background: #f9f8fa; border-top: 1px solid #dddae2; text-align: center;">
+              <p style="margin: 0; font-size: 13px; color: #594d73; line-height: 1.5;">
+                ${testBanner ? '[TEST EMAIL, not a real campaign send]<br />' : ''}
+                You're receiving this because you bought several Devcon 8 India tickets.<br />
+                See you in Mumbai! 🇮🇳 The Devcon Team 💜
+              </p>
+            </td>
+          </tr>
+        </table>
+      </td>
+    </tr>
+  </table>
+</body>
+</html>`
+}
+
+/** Emails already marked sent in a previous results CSV (for --skip-sent). */
+function loadAlreadySent(file: string): Set<string> {
+  const sent = new Set<string>()
+  for (const line of fs.readFileSync(file, 'utf8').split('\n')) {
+    const cells = line.split(',')
+    if (cells[cells.length - 1]?.trim() === 'sent') sent.add(cells[0]?.trim().toLowerCase())
+  }
+  return sent
+}
+
+const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+/** Sample content for a --test-to run without --as: no real buyer involved. */
+function sampleRecipient(to: string): Recipient {
+  return {
+    email: to,
+    orders: [
+      { code: 'ABCDE', url: pretixEventUrl('/order/ABCDE/sample/'), datetime: '2026-06-01T10:00:00Z', ticketsWithBuyer: 3 },
+      { code: 'FGHIJ', url: pretixEventUrl('/order/FGHIJ/sample/'), datetime: '2026-07-01T10:00:00Z', ticketsWithBuyer: 2 },
+    ],
+  }
+}
+
+async function main() {
+  console.log('Pretix API:', eventUrl('/'))
+  console.log('Environment:', TICKETING_ENV)
+  console.log('')
+
+  console.log('Reading items and paid orders from Pretix (read-only)...')
+  const [admissionItems, orders] = await Promise.all([fetchAdmissionItemIds(), fetchPaidOrders()])
+  let recipients = selectRecipients(orders, admissionItems)
+  const ticketsTotal = recipients.reduce((n, r) => n + r.orders.reduce((m, o) => m + o.ticketsWithBuyer, 0), 0)
+  console.log(`  ${orders.length} paid orders, ${recipients.length} buyers hold ${ticketsTotal} tickets still under their own email (2+ in total)`)
+  console.log('')
+
+  if (skipSentPath) {
+    const done = loadAlreadySent(skipSentPath)
+    const before = recipients.length
+    recipients = recipients.filter(r => !done.has(r.email))
+    console.log(`--skip-sent: ${before - recipients.length} already sent, ${recipients.length} remaining`)
+  }
+  if (limit !== null && Number.isFinite(limit)) {
+    recipients = recipients.slice(0, limit)
+    console.log(`--limit: ${recipients.length} recipient(s)`)
+  }
+
+  // ---- ONE test email to a chosen inbox ----
+  if (testTo) {
+    const source = testAs ? recipients.find(r => r.email === testAs.toLowerCase()) : null
+    if (testAs && !source) throw new Error(`--as ${testAs} is not among the recipients`)
+    const recipient: Recipient = source ? { ...source, email: testTo } : sampleRecipient(testTo)
+    console.log(`*** TEST: sending ONE email to ${testTo} (${source ? `content of ${testAs}` : 'sample content'}) ***`)
+    const transporter = getTransporter()
+    await sendWithRetry(transporter, { from: DEFAULT_FROM, to: testTo, subject: `[TEST] ${SUBJECT}`, html: buildReminderHtml(recipient, true) })
+    console.log('Sent. Nothing else was sent.')
+    return
+  }
+
+  // ---- DRY RUN ----
+  if (!doSend) {
+    const previewDir = 'generated-codes/previews'
+    fs.mkdirSync(previewDir, { recursive: true })
+    for (const r of recipients.slice(0, 20)) {
+      const safeName = r.email.replace(/[^a-z0-9.@-]/gi, '_')
+      fs.writeFileSync(path.join(previewDir, `attendee-email-reminder-${safeName}.html`), buildReminderHtml(r))
+    }
+    // A preview with made-up data too, safe to open or share without exposing a buyer.
+    fs.writeFileSync(path.join(previewDir, 'attendee-email-reminder-SAMPLE.html'), buildReminderHtml(sampleRecipient('you@example.com'), true))
+    const listPath = `generated-codes/attendee-email-reminder-recipients-${new Date().toISOString().slice(0, 10)}.csv`
+    fs.writeFileSync(listPath, 'email,orders,tickets\n' + recipients.map(r => `${r.email},${r.orders.map(o => o.code).join(' ')},${r.orders.reduce((n, o) => n + o.ticketsWithBuyer, 0)}`).join('\n') + '\n')
+    console.log('*** DRY RUN: no emails sent ***')
+    console.log(`Subject: ${SUBJECT}`)
+    console.log('')
+    for (const r of recipients) {
+      console.log(`  ${r.email}  ${r.orders.map(o => `${o.code} (${o.ticketsWithBuyer} tickets)`).join(', ')}`)
+    }
+    console.log('')
+    console.log(`Recipient list: ${listPath}`)
+    console.log(`Up to 20 HTML previews written to ${previewDir}/attendee-email-reminder-*.html (plus -SAMPLE.html with made-up data)`)
+    console.log('Check in Pretix that customers may change attendee details ("Customers can modify their')
+    console.log('orders until" unset or in the future), then --test-to you@example.com for one test email,')
+    console.log('or --send for the full list.')
+    return
+  }
+
+  // ---- LIVE SEND ----
+  console.log(`*** LIVE SEND to ${recipients.length} recipient(s) ***`)
+  console.log(`Subject: ${SUBJECT}`)
+  console.log('')
+  const transporter = getTransporter()
+  const resultsPath = `generated-codes/attendee-email-reminder-results-${new Date().toISOString().replace(/[:.]/g, '-')}.csv`
+  fs.mkdirSync(path.dirname(resultsPath), { recursive: true })
+  fs.writeFileSync(resultsPath, 'email,orders,status\n')
+
+  let sent = 0
+  let failed = 0
+  for (let i = 0; i < recipients.length; i++) {
+    const r = recipients[i]
+    const codes = r.orders.map(o => o.code).join(' ')
+    try {
+      await sendWithRetry(transporter, { from: DEFAULT_FROM, to: r.email, subject: SUBJECT, html: buildReminderHtml(r) })
+      fs.appendFileSync(resultsPath, `${r.email},${codes},sent\n`)
+      console.log(`  [${i + 1}/${recipients.length}] sent -> ${r.email} (${codes})`)
+      sent++
+    } catch (err) {
+      fs.appendFileSync(resultsPath, `${r.email},${codes},failed\n`)
+      console.error(`  [${i + 1}/${recipients.length}] FAILED ${r.email}: ${(err as Error).message}`)
+      failed++
+    }
+    if (i < recipients.length - 1) await sleep(300)
+  }
+
+  console.log('')
+  console.log('=== Summary ===')
+  console.log(`  Sent:    ${sent}`)
+  console.log(`  Failed:  ${failed}`)
+  console.log(`  Results: ${resultsPath}`)
+}
+
+main().catch(err => {
+  console.error('Error:', err.message || err)
+  process.exit(1)
+})

--- a/event-app/.env.example
+++ b/event-app/.env.example
@@ -90,9 +90,10 @@ TICKET_PROOF_SALT=your_random_identifier_salt
 # TICKET_STYLE_GOLDEN_ITEM_IDS=2
 
 # Optional test fixture (src/app/api/tickets/testFixture.ts): each listed order
-# gets N fake India Resident tickets plus a t-shirt add-on and a Chess Set, so
-# the ENS proof flow, the multi-ticket layout and the swag shelf can be
-# exercised without buying. "CODE" or "CODE:N", comma-separated.
+# spawns a TEST-<code> order with N fake India Resident tickets (the first with
+# a t-shirt add-on and a collected Chess Set), choosable like real tickets, so
+# the ENS proof flow, the ticket select and the swag shelf can be exercised
+# without buying. "CODE" or "CODE:N", comma-separated.
 # TICKET_TEST_INDIA_ORDER_CODE=ABCDE:2,FGHIJ
 
 # Host serving the og:image social cards (devcon/src/pages/api/social/*).

--- a/event-app/CLAUDE.md
+++ b/event-app/CLAUDE.md
@@ -210,7 +210,9 @@ sole email match, else the tab asks.
   the same string on the card, the select rows and the buyer links.
 - **Buyer nudge** (`BuyerOrdersHint`): whenever the account is the order email
   and holds more than one ticket in total, one chip per ticket links to the
-  Pretix order page so holders get their own email there.
+  Pretix order page so holders get their own email there. The same nudge goes
+  out by email before the event from the devcon package
+  (`pnpm run send-attendee-email-reminder`, dry run by default).
 - **Swag** shows "Collected" from a Pretix entry check-in on the add-on or
   merchandise position (`positionCollected`); no list configuration, since
   Pretix only records a scan against a list that includes that product.

--- a/event-app/CLAUDE.md
+++ b/event-app/CLAUDE.md
@@ -43,7 +43,7 @@ correctly.
 
 ## Hard rules
 
-- **Catalogue data goes through the EventStore** (`src/data/store/`): sessions, speakers, rooms and the event record are one bundle from `GET /events/:id/bundle`, stored normalised in Dexie and synced only when `GET /events/:id/version` changes (60 bytes). Read it through the hooks in `src/data/hooks/` (`useSessions`, `useSpeaker`, …); never fetch catalogue data anywhere else. Adding a field means updating devcon-api's bundle allowlist, `store/types.ts`, `normalize.ts`, `materialize.ts` and the `data:test` fixture. Other persisted state (announcements, tickets, stars) goes through the Dexie-backed SWR layer, never ad-hoc fetch + useState. The service worker has no rule for `/api/*` (requests reach the browser untouched; routing them through the worker made Safari's cold-started worker fail the first request after a pause) and the devcon-api origin is never cached by it.
+- **Catalogue data goes through the EventStore** (`src/data/store/`): sessions, speakers, rooms and the event record are one bundle from `GET /events/:id/bundle`, stored normalised in Dexie and synced only when `GET /events/:id/version` changes (60 bytes). Read it through the hooks in `src/data/hooks/` (`useSessions`, `useSpeaker`, …); never fetch catalogue data anywhere else. Adding a field means updating devcon-api's bundle allowlist, `store/types.ts`, `normalize.ts`, `materialize.ts` and the `data:test` fixture. Other persisted state (announcements, tickets, stars) goes through the Dexie-backed SWR layer, never ad-hoc fetch + useState. Interested stars additionally sync to the account when signed in (`src/data/interested/sync.ts`, `POST /api/interests/sync`, table `devcon8_interests`): Dexie rows carry `interested` (false is a tombstone), `updatedAt` and `pending`; never delete a star row, put a tombstone; conflicts are last-write-wins per item; stars stay on the device after sign-out by decision. The service worker has no rule for `/api/*` (requests reach the browser untouched; routing them through the worker made Safari's cold-started worker fail the first request after a pause) and the devcon-api origin is never cached by it.
 - **The five bottom-bar tabs are persistent panes** (`src/components/TabPanes.tsx`): their route `page.tsx` files render nothing and the layout keeps each visited pane mounted, toggling `hidden` on tab switches (a page mount of the speakers list cost ~800 ms on a mid-range phone; a toggle is a few ms) and restoring each tab's scroll position. Consequences: anything that portals into the app header or measures the window on scroll must check `usePaneActive()` (`src/components/paneContext.ts`), or every mounted pane does it at once, and IntersectionObserver callbacks must ignore 0×0 rects (a hidden pane's elements); long lists render group by group in the background with `useProgressiveReveal` (`src/hooks/useProgressiveReveal.ts`) so first mount costs a screenful, and jumps call `revealAll()` first so they measure real heights (never render-on-viewport-approach: A–Z jumps then landed on placeholders and the content shifted under the finger); the schedule jumps to "live now" only on app open. Every vertical page jump is instant (`behavior: "auto"`), never smooth: WebKit rasterises everything a smooth scroll passes over and a rapid series crashed iOS (PR #112). Tab taps give a haptic tick: Android via the Vibration API (`utils/haptics.ts`), iOS via a transparent `<input type="checkbox" switch>` overlay inside each tab link (`IosHapticOverlay`; the only path left since iOS 26.5 closed programmatic ticks, an undocumented side effect that may stop working, failing silently). Re-tapping the active tab resets its pane like a native tab bar (`handleTabClick` + `useTabReselect` in `paneContext.ts`): instant scroll to top by default, the schedule jumps to "now", the map resets filters and view (`resetView` in VenueMap); with a detail page open the tap navigates to the bare tab URL, which closes it.
 - **Detail pages are real paths that open in place.** `/schedule/<id>` and `/speakers/<id>` are the only detail URLs (shared, crawled, pushed). The route files (`schedule/[id]/page.tsx`, `speakers/[id]/page.tsx`) exist for the URL and its `generateMetadata` and render nothing on the client: the list tab's pane renders the page (`session.tsx` / `speaker.tsx`, mobile as a `DetailLayer` over the list, desktop in place of it; the desktop side panel is local state, not the URL). In the app a detail opens with `openDetail` / `useDetailRoute` (`src/routing/detailRoute.ts`: Next-integrated `history.pushState`, no RSC fetch), links are `DetailLink` (a plain anchor with the real href; never `next/link`, which prefetches per card). Offline, the SW answers a navigation to a detail path with the precached tab shell (`src/sw.ts`), so a never-visited id works too; `/schedule/[id]` is never precached per id. Build hrefs with `detailHref(kind, id)` (`src/routing/viewParams.ts`, also imported by the SW). `/room-screens/[id]` is the deliberate exception (TV kiosk, always online).
 - **Live-only features degrade, never error**: gate Q&A, streams, chat, sign-in, push and refresh on `useOnline()` and render `<NeedsConnection what="…" />` in the feature's slot.
@@ -163,3 +163,59 @@ Three things not to undo: the signer address is never carried in the proof link
 is a *salted* HMAC of the ticket secret (the secret is the QR payload, so a bare
 hash would deanonymise claims), and the signing key is dedicated and funds-free
 (never the payment relayer key).
+
+## Attached tickets (which ticket is yours)
+
+Sign-in stays the email OTP. `/api/tickets` returns tickets matched by the
+session email plus positions the account attached (`devcon8_ticket_links`,
+service-role only). Attached tickets come first and carry `attached: true`;
+every ticket carries its Pretix `positionId`. The client derives one primary
+ticket and which prompt to show with the pure helpers in
+`src/data/tickets/primary.ts` (`pnpm data:test`): an attached ticket, else the
+sole email match, else the tab asks.
+
+- **Two proofs, one endpoint** (`POST /api/tickets/attach`): `{ positionId }`
+  chooses one of the account's own email-matched admission positions (the
+  email match is the proof); `{ code }` is the QR payload of a ticket not under
+  this email, verified against Pretix (`getPositionBySecret`, this event, paid,
+  live, not an add-on). The link records its `proof` (`email` or `qr`) and a
+  SHA-256 of the secret, never the secret. `DELETE { positionId }` detaches.
+- **Upload formats**, all decoded on the device (`src/data/tickets/qrFromFile.ts`,
+  imported dynamically): a screenshot or photo (jsQR, `qrDecode.ts`,
+  `pnpm qr:test`), a `.pkpass` wallet pass (payload is text in its `pass.json`,
+  `passBarcode.ts`), or the ticket PDF (pages rendered with pdf.js, loaded on
+  demand). No camera scanner, no deep links; never log the code.
+- **Re-verification on every fetch**: gone, canceled or unpaid positions are
+  dropped, and so is an `email`-proof link whose attendee email no longer
+  matches the account (the buyer reassigned it); `removedAttachments` drives
+  the one-line notice. Link reads are best effort: a Supabase error falls back
+  to email-matched tickets, never a failed tab.
+- **Redaction**: a `qr`-proof ticket comes back with the buyer's identity
+  replaced by the account (`redactBuyerIdentity`: order email, attendee and
+  add-on names, order page URL), since the QR proves possession, not who paid.
+  The Pretix order page URL (`Order.url`, carries the order secret) is exposed
+  only when the account email is the order email.
+- **Two accounts may attach the same ticket** (the door arbitrates, not us):
+  such tickets carry `sharedWith` and the card and select rows say so.
+- **The tab**: several email-matched tickets and none chosen shows the select
+  ("Which ticket is yours?", "This one is mine") with the upload as a fallback,
+  and no QR codes until chosen; offline it falls back to showing the saved
+  tickets. No ticket under the email shows the upload card. Only the primary is
+  shown, with its add-ons and its perk; the buyer's other tickets stay in the
+  Pretix email. Footer: "Not your ticket? Attach yours" replaces an
+  email-matched ticket, "Wrong ticket? Choose another" (or "Remove it from this
+  account" when no select would follow) detaches an attached one. Tickets are
+  numbered for people as "Order KXQFQ · Ticket #1" (`ticketOrdinals`: 1..n per
+  order over the tickets the account sees, so Pretix position gaps never show),
+  the same string on the card, the select rows and the buyer links.
+- **Buyer nudge** (`BuyerOrdersHint`): whenever the account is the order email
+  and holds more than one ticket in total, one chip per ticket links to the
+  Pretix order page so holders get their own email there.
+- **Swag** shows "Collected" from a Pretix entry check-in on the add-on or
+  merchandise position (`positionCollected`); no list configuration, since
+  Pretix only records a scan against a list that includes that product.
+- **Q&A eligibility** (`/api/meerkat`) counts attached tickets.
+- **Fixture** (`TICKET_TEST_INDIA_ORDER_CODE`, dev/preview): fake tickets live
+  on their own `TEST-<code>` order, are flagged `test`, carry negative
+  synthetic position ids so they can be chosen (the server skips Pretix for
+  those), and the first one holds the fake shirt and collected chess set.

--- a/event-app/CLAUDE.md
+++ b/event-app/CLAUDE.md
@@ -188,7 +188,8 @@ sole email match, else the tab asks.
 - **Re-verification on every fetch**: gone, canceled or unpaid positions are
   dropped, and so is an `email`-proof link whose attendee email no longer
   matches the account (the buyer reassigned it); `removedAttachments` drives
-  the one-line notice. Link reads are best effort: a Supabase error falls back
+  the one-line notice. Only a 404 counts as gone (`pretixLookupOutcome`); any
+  other Pretix failure throws so a 429 or 500 can never delete a link. Link reads are best effort: a Supabase error falls back
   to email-matched tickets, never a failed tab.
 - **Redaction**: a `qr`-proof ticket comes back with the buyer's identity
   replaced by the account (`redactBuyerIdentity`: order email, attendee and
@@ -216,7 +217,8 @@ sole email match, else the tab asks.
 - **Swag** shows "Collected" from a Pretix entry check-in on the add-on or
   merchandise position (`positionCollected`); no list configuration, since
   Pretix only records a scan against a list that includes that product.
-- **Q&A eligibility** (`/api/meerkat`) counts attached tickets.
+- **Q&A eligibility** (`/api/meerkat`) and the ENS perk (`/api/ticket-proof`)
+  resolve tickets with `getTicketsForUser`, so attached tickets count.
 - **Fixture** (`TICKET_TEST_INDIA_ORDER_CODE`, dev/preview): fake tickets live
   on their own `TEST-<code>` order, are flagged `test`, carry negative
   synthetic position ids so they can be chosen (the server skips Pretix for

--- a/event-app/CLAUDE.md
+++ b/event-app/CLAUDE.md
@@ -205,7 +205,7 @@ sole email match, else the tab asks.
   Pretix email. Footer: "Not your ticket? Attach yours" replaces an
   email-matched ticket, "Wrong ticket? Choose another" (or "Remove it from this
   account" when no select would follow) detaches an attached one. Tickets are
-  numbered for people as "Order KXQFQ · Ticket #1" (`ticketOrdinals`: 1..n per
+  numbered for people as "Order ABCDE · Ticket #1" (`ticketOrdinals`: 1..n per
   order over the tickets the account sees, so Pretix position gaps never show),
   the same string on the card, the select rows and the buyer links.
 - **Buyer nudge** (`BuyerOrdersHint`): whenever the account is the order email

--- a/event-app/docs/architecture.md
+++ b/event-app/docs/architecture.md
@@ -76,8 +76,16 @@ Catalogue data (sessions, speakers, rooms, the event record) lives in the **Even
   parallel and renders children when both are ready, so the first paint has data and no flash.
 
 SWR + the Dexie `cache` table remain for the small, differently-shaped state: announcements,
-tickets, and browser-local user state (interested stars, announcement read state). Dexie is used
+tickets, and browser-local user state (interested stars, which also sync to the account when signed
+in via `POST /api/interests/sync`; announcement read state). Dexie is used
 because IndexedDB has far larger limits than localStorage; abstract it away behind hooks.
+
+Ticket identity: the Supabase account (email OTP) is the identity; `/api/tickets` returns tickets
+matched by email plus positions the account attached (`devcon8_ticket_links`), attached first. The
+client derives one primary ticket (`src/data/tickets/primary.ts`): an attached ticket, else the sole
+email match, else the tab asks (a select among the email-matched tickets, or an upload of the ticket
+as a screenshot, PDF or `.pkpass`, decoded on the device). Only the primary is shown; see `CLAUDE.md`
+for the rules.
 
 Offline UX: `useOnline` (`src/hooks/useOnline.ts`) is the single connectivity source. The header
 marker is an icon-only pill whose tooltip/aria-label reads "Offline, schedule from HH:MM" (last sync time), image retries hang off the same

--- a/event-app/package.json
+++ b/event-app/package.json
@@ -20,7 +20,8 @@
     "otp:test": "tsx scripts/test-otp-input.ts",
     "proof:test": "tsx scripts/test-ticket-proof.ts",
     "proof:demo-link": "tsx scripts/make-demo-proof.ts",
-    "data:test": "tsx scripts/test-data.ts"
+    "data:test": "tsx scripts/test-data.ts",
+    "qr:test": "tsx scripts/test-qr-decode.ts"
   },
   "dependencies": {
     "@capacitor/android": "^8.0.1",
@@ -36,11 +37,14 @@
     "@supabase/supabase-js": "^2.106.2",
     "classnames": "^2.5.1",
     "dexie": "^4.2.1",
+    "fflate": "^0.8.3",
     "framer-motion": "12.0.0-alpha.1",
+    "jsqr": "^1.4.0",
     "lib": "workspace:*",
     "lucide-react": "^1.17.0",
     "next": "16.1.1",
     "panzoom": "^9.4.3",
+    "pdfjs-dist": "^6.3.289",
     "qrcode": "^1.5.4",
     "react": "19.2.3",
     "react-dom": "19.2.3",

--- a/event-app/scripts/test-data.ts
+++ b/event-app/scripts/test-data.ts
@@ -14,6 +14,15 @@ import {
 } from "../src/routing/viewParams";
 import { isTransientFetchError, retryOnce } from "../src/utils/retryOnce";
 import { whenControlled, type ServiceWorkerControl } from "../src/utils/serviceWorkerControl";
+import { buyerOrdersToAssign, derivePrimary, ticketChoices, ticketOrdinals, ticketPrompt } from "../src/data/tickets/primary";
+import type { Order } from "../src/data/tickets/types";
+import { createRateLimiter } from "../src/app/api/tickets/rateLimit";
+import { positionCollected, positionMatchesEmail, redactBuyerIdentity } from "../src/app/api/tickets/pretix";
+import { readPassBarcode } from "../src/data/tickets/passBarcode";
+import { isUnsupportedPhotoFormat } from "../src/data/tickets/qrFromFile";
+import { strToU8, zipSync } from "fflate";
+import { mergeRemote, settlePending } from "../src/data/interested/merge";
+import { parseSyncBody } from "../src/data/interested/syncProtocol";
 
 let failed = 0;
 const check = (label: string, ok: boolean, note = "") => {
@@ -212,11 +221,146 @@ async function testWhenControlled() {
   check("whenControlled: resolves true once the worker claims the page", settled === true);
 }
 
+function ticket(secret: string, extra: Partial<Order["tickets"][number]> = {}): Order["tickets"][number] {
+  return { secret, attendeeName: null, attendeeEmail: "a@b.c", price: "0", itemName: "T", addons: [], ...extra };
+}
+const order = (code: string, tickets: Order["tickets"]): Order => ({ orderCode: code, orderDate: "", email: "a@b.c", tickets });
+
+function testPrimary() {
+  const one = [order("A", [ticket("s1")])];
+  check("primary: the only email-matched ticket", derivePrimary(one)?.secret === "s1");
+  check("prompt: none needed with one ticket", ticketPrompt(one) === null);
+
+  const two = [order("A", [ticket("s1"), ticket("s2")])];
+  check("primary: none with two email-matched tickets", derivePrimary(two) === null);
+  check("prompt: choose with two tickets", ticketPrompt(two) === "choose");
+
+  const attached = [order("B", [ticket("s9", { attached: true })]), ...two];
+  check("primary: attached ticket wins", derivePrimary(attached)?.secret === "s9");
+  check("prompt: none once attached", ticketPrompt(attached) === null);
+
+  const swagOnly = [order("A", [ticket("m1", { admission: false })])];
+  check("primary: swag is never primary", derivePrimary(swagOnly) === null);
+  check("prompt: none-found when only swag", ticketPrompt(swagOnly) === "none");
+  check("prompt: none-found with no orders", ticketPrompt([]) === "none");
+
+  const buyerOrder = order("A", [
+    ticket("s1", { positionId: 11, positionNumber: 1, attendeeName: "Ada", addons: [{ id: 1, secret: "x", itemName: "Shirt - L", price: "0", attendeeName: null }] }),
+    ticket("s2", { positionId: 12, positionNumber: 2, sharedWith: 1 }),
+    ticket("m1", { admission: false, positionId: 13 }),
+  ]);
+  buyerOrder.url = "https://tickets.example/order/A/secret/";
+  const choices = ticketChoices([buyerOrder, order("B", [ticket("fixture")])]);
+  check("choices: numbered 1..n within the order", choices[0].ordinal === 1 && choices[1].ordinal === 2 && choices[2].ordinal === 1);
+  const gapped = order("G", [ticket("g1", { positionId: 1, positionNumber: 1 }), ticket("g3", { positionId: 3, positionNumber: 3 })]);
+  check("ordinals: Pretix gaps close (positions 1 and 3 read as #1 and #2)", eq([...ticketOrdinals([gapped]).values()], [1, 2]));
+  const toAssign = buyerOrdersToAssign([buyerOrder, order("B", [ticket("fixture")])]);
+  check("buyer orders: several tickets under the buyer's email, with the order page", toAssign.length === 1 && toAssign[0].orderCode === "A" && toAssign[0].tickets.length === 2 && toAssign[0].url === buyerOrder.url);
+  const withFixture = order("F", [ticket("real", { positionId: 1, positionNumber: 1 }), ticket("fake-fixture")]);
+  withFixture.url = "https://tickets.example/order/F/secret/";
+  check("buyer orders: fixture tickets without a position do not count", buyerOrdersToAssign([withFixture]).length === 0);
+  check("buyer orders: tickets listed with their numbers", eq(toAssign[0].tickets.map((t) => t.ordinal), [1, 2]));
+  const single = order("C", [ticket("c1"), ticket("c2")]);
+  check("buyer orders: no order page means not the buyer, no hint", buyerOrdersToAssign([single]).length === 0);
+  // After a choice the chosen ticket and the rest arrive as two objects for one order.
+  const chosen = order("A", [ticket("s1", { positionId: 11, positionNumber: 1, attached: true })]);
+  chosen.url = buyerOrder.url;
+  const rest = order("A", [ticket("s2", { positionId: 12, positionNumber: 2 })]);
+  rest.url = buyerOrder.url;
+  const afterChoice = buyerOrdersToAssign([chosen, rest]);
+  check("buyer orders: after a choice both tickets stay listed, same as before", afterChoice.length === 1 && eq(afterChoice[0].tickets.map((t) => [t.secret, t.ordinal]), [["s1", 1], ["s2", 2]]));
+  const d = order("D", [ticket("d1", { positionId: 21, positionNumber: 1 })]);
+  d.url = "https://tickets.example/order/D/secret/";
+  const e = order("E", [ticket("e1", { positionId: 31, positionNumber: 1 })]);
+  e.url = "https://tickets.example/order/E/secret/";
+  const attendeeOnly = order("Y", [ticket("y1", { positionId: 41, positionNumber: 1 })]);
+  check("buyer orders: several single-ticket orders count together; a ticket bought by someone else does not", eq(buyerOrdersToAssign([d, e, attendeeOnly]).map((o) => o.orderCode), ["D", "E"]));
+  check("buyer orders: one ticket in total, no hint", buyerOrdersToAssign([d]).length === 0);
+  check("choices: other holders flagged", choices[1].sharedWith === 1 && choices[0].sharedWith === undefined);
+  check("choices: admission tickets only, in order", eq(choices.map((c) => c.secret), ["s1", "s2", "fixture"]));
+  check("choices: holder, add-ons and order carried", choices[0].holder === "Ada" && eq(choices[0].addons, ["Shirt - L"]) && choices[0].orderCode === "A");
+  check("choices: email fallback for the holder", choices[1].holder === "a@b.c");
+  check("choices: id-less ticket cannot be chosen", choices[2].positionId === undefined);
+  const fixtureOrder = order("TEST-A", [ticket("fx", { positionId: -1, positionNumber: 1, test: true })]);
+  check("choices: fixture ticket is choosable and marked test", ticketChoices([fixtureOrder])[0].positionId === -1 && ticketChoices([fixtureOrder])[0].test === true);
+  check("primary: a chosen fixture ticket leads like a real one", derivePrimary([order("TEST-A", [ticket("fx", { positionId: -1, attached: true, test: true })]), buyerOrder])?.secret === "fx");
+
+  check("email match: attendee email wins, case-insensitive", positionMatchesEmail({ attendee_email: "Ada@Example.com" }, "buyer@example.com", "ada@example.com"));
+  check("email match: falls back to the order email", positionMatchesEmail({ attendee_email: null }, "buyer@example.com", "buyer@example.com"));
+  check("email match: reassigned ticket no longer matches the buyer", !positionMatchesEmail({ attendee_email: "colleague@example.com" }, "buyer@example.com", "buyer@example.com"));
+
+  const bought = order("Z", [
+    ticket("q1", { attendeeEmail: "buyer@example.com", attendeeName: "Buyer Name", addons: [{ id: 1, secret: "x", itemName: "Shirt", price: "0", attendeeName: "Buyer Name" }] }),
+  ]);
+  bought.email = "buyer@example.com";
+  bought.url = "https://tickets.example/order/Z/secret/";
+  const redacted = redactBuyerIdentity(bought, "holder@example.com");
+  check("redact: buyer email and names removed from a QR-attached ticket", redacted.email === "holder@example.com" && redacted.tickets[0].attendeeEmail === "holder@example.com" && redacted.tickets[0].attendeeName === null && redacted.tickets[0].addons[0].attendeeName === null);
+  check("redact: order page url withheld from a QR holder", redacted.url === undefined);
+  check("redact: original order untouched", bought.tickets[0].attendeeName === "Buyer Name");
+  const own = redactBuyerIdentity(bought, "Buyer@Example.com");
+  check("redact: the holder's own ticket keeps its name", own.tickets[0].attendeeName === "Buyer Name" && own.email === "buyer@example.com");
+
+  check("collected: an entry scan counts", positionCollected({ checkins: [{ list: 1, type: "entry" }] }));
+  check("collected: a scan with no type is an entry", positionCollected({ checkins: [{ list: 1 }] }));
+  check("collected: an exit scan does not count", !positionCollected({ checkins: [{ list: 1, type: "exit" }] }));
+  check("collected: no scans", !positionCollected({ checkins: [] }) && !positionCollected({}));
+}
+
+function testRateLimiter() {
+  let t = 0;
+  const limiter = createRateLimiter(3, 1000, () => t);
+  check("rate limit: first three allowed", limiter.allow("u") && limiter.allow("u") && limiter.allow("u"));
+  check("rate limit: fourth blocked", !limiter.allow("u"));
+  check("rate limit: other key unaffected", limiter.allow("v"));
+  t = 1001;
+  check("rate limit: window slides", limiter.allow("u"));
+}
+
+function testInterestsMerge() {
+  const local = { interested: true, updatedAt: 1000, pending: 0 };
+  check("interests: newer remote tombstone wins", eq(mergeRemote(local, { interested: false, updatedAt: 2000 }), { interested: false, updatedAt: 2000, pending: 0 }));
+  check("interests: tie keeps local", mergeRemote(local, { interested: false, updatedAt: 1000 }) === null);
+  check("interests: older remote ignored", mergeRemote(local, { interested: false, updatedAt: 500 }) === null);
+  check("interests: unknown item adopted from the account", eq(mergeRemote(undefined, { interested: true, updatedAt: 7 }), { interested: true, updatedAt: 7, pending: 0 }));
+  const pending = { interested: true, updatedAt: 3000, pending: 1 };
+  check("interests: pushed row settles when unchanged", eq(settlePending(pending, 3000), { interested: true, updatedAt: 3000, pending: 0 }));
+  check("interests: row changed in flight stays pending", settlePending({ ...pending, updatedAt: 3500 }, 3000) === null);
+
+  const now = 10_000_000;
+  const ok = parseSyncBody({ event: "devcon8", since: null, changes: [{ kind: "session", id: "abc-1", interested: true, updatedAt: 1234.7 }] }, now);
+  check("sync body: valid request parses (updatedAt floored)", ok?.event === "devcon8" && ok.since === null && ok.changes[0].updatedAt === 1234);
+  const ahead = parseSyncBody({ event: "devcon8", since: 5, changes: [{ kind: "speaker", id: "x", interested: false, updatedAt: now + 3_600_000 }] }, now);
+  check("sync body: future timestamps clamped", ahead?.changes[0].updatedAt === now + 60_000);
+  check("sync body: bad kind rejected", parseSyncBody({ event: "devcon8", since: null, changes: [{ kind: "room", id: "x", interested: true, updatedAt: 1 }] }) === null);
+  check("sync body: bad event rejected", parseSyncBody({ event: "Devcon 8", since: null, changes: [] }) === null);
+  check("sync body: negative since rejected", parseSyncBody({ event: "devcon8", since: -1, changes: [] }) === null);
+  check("sync body: too many changes rejected", parseSyncBody({ event: "devcon8", since: null, changes: Array.from({ length: 501 }, (_, i) => ({ kind: "session", id: `s${i}`, interested: true, updatedAt: 1 })) }) === null);
+}
+
+function testPassBarcode() {
+  const pass = (json: unknown) => zipSync({ "pass.json": strToU8(JSON.stringify(json)), "icon.png": new Uint8Array([0]) });
+  check("pkpass: QR barcode message read", readPassBarcode(pass({ barcodes: [{ format: "PKBarcodeFormatQR", message: "abc123secret", messageEncoding: "iso-8859-1" }] })) === "abc123secret");
+  check("pkpass: QR preferred over other formats", readPassBarcode(pass({ barcodes: [{ format: "PKBarcodeFormatPDF417", message: "other" }, { format: "PKBarcodeFormatQR", message: "qr" }] })) === "qr");
+  check("pkpass: legacy single barcode read", readPassBarcode(pass({ barcode: { format: "PKBarcodeFormatQR", message: "legacy" } })) === "legacy");
+  check("pkpass: no barcode is null", readPassBarcode(pass({ description: "no codes" })) === null);
+  check("pkpass: zip without pass.json is null", readPassBarcode(zipSync({ "readme.txt": strToU8("x") })) === null);
+  check("pkpass: not a zip is null", readPassBarcode(new Uint8Array([1, 2, 3, 4])) === null);
+
+  const blob = (name: string, type: string) => Object.assign(new Blob([new Uint8Array(4)], { type }), { name });
+  check("photo format: HEIC by type or extension is flagged", isUnsupportedPhotoFormat(blob("IMG_1.heic", "")) && isUnsupportedPhotoFormat(blob("x", "image/heic")) && isUnsupportedPhotoFormat(blob("scan.tiff", "image/tiff")));
+  check("photo format: PNG, JPEG and PDF are not", !isUnsupportedPhotoFormat(blob("shot.png", "image/png")) && !isUnsupportedPhotoFormat(blob("p.jpg", "image/jpeg")) && !isUnsupportedPhotoFormat(blob("t.pdf", "application/pdf")));
+}
+
 async function main() {
   testNormalize();
+  testPassBarcode();
   testMaterialize();
   testSyncDecision();
   testRouting();
+  testPrimary();
+  testRateLimiter();
+  testInterestsMerge();
   await testRetryOnce();
   await testWhenControlled();
   console.log(failed ? `\n${failed} check(s) failed` : "\nall checks passed");

--- a/event-app/scripts/test-data.ts
+++ b/event-app/scripts/test-data.ts
@@ -17,7 +17,7 @@ import { whenControlled, type ServiceWorkerControl } from "../src/utils/serviceW
 import { buyerOrdersToAssign, derivePrimary, ticketChoices, ticketOrdinals, ticketPrompt } from "../src/data/tickets/primary";
 import type { Order } from "../src/data/tickets/types";
 import { createRateLimiter } from "../src/app/api/tickets/rateLimit";
-import { positionCollected, positionMatchesEmail, redactBuyerIdentity } from "../src/app/api/tickets/pretix";
+import { positionCollected, positionMatchesEmail, pretixLookupOutcome, redactBuyerIdentity } from "../src/app/api/tickets/pretix";
 import { readPassBarcode } from "../src/data/tickets/passBarcode";
 import { isUnsupportedPhotoFormat } from "../src/data/tickets/qrFromFile";
 import { strToU8, zipSync } from "fflate";
@@ -317,6 +317,10 @@ function testPrimary() {
   check("collected: a scan with no type is an entry", positionCollected({ checkins: [{ list: 1 }] }));
   check("collected: an exit scan does not count", !positionCollected({ checkins: [{ list: 1, type: "exit" }] }));
   check("collected: no scans", !positionCollected({ checkins: [] }) && !positionCollected({}));
+
+  check("link re-verification: 200 is ok", pretixLookupOutcome({ ok: true, status: 200 }) === "ok");
+  check("link re-verification: 404 means the position or order is gone", pretixLookupOutcome({ ok: false, status: 404 }) === "missing");
+  check("link re-verification: 429 and 500 fail without deleting anything", pretixLookupOutcome({ ok: false, status: 429 }) === "failed" && pretixLookupOutcome({ ok: false, status: 500 }) === "failed");
 }
 
 function testRateLimiter() {

--- a/event-app/scripts/test-data.ts
+++ b/event-app/scripts/test-data.ts
@@ -276,6 +276,18 @@ function testPrimary() {
   const attendeeOnly = order("Y", [ticket("y1", { positionId: 41, positionNumber: 1 })]);
   check("buyer orders: several single-ticket orders count together; a ticket bought by someone else does not", eq(buyerOrdersToAssign([d, e, attendeeOnly]).map((o) => o.orderCode), ["D", "E"]));
   check("buyer orders: one ticket in total, no hint", buyerOrdersToAssign([d]).length === 0);
+
+  // Rows and chips share one order: orders as placed, tickets by position,
+  // whatever the payload order (a chosen ticket's order moves to the front).
+  const older = order("OLD", [ticket("o2", { positionId: 2, positionNumber: 2 }), ticket("o1", { positionId: 1, positionNumber: 1 })]);
+  older.orderDate = "2026-01-01T00:00:00Z"; older.url = "https://tickets.example/order/OLD/s/";
+  const newer = order("NEW", [ticket("n1", { positionId: 3, positionNumber: 1 })]);
+  newer.orderDate = "2026-02-01T00:00:00Z"; newer.url = "https://tickets.example/order/NEW/s/";
+  const rows = ticketChoices([older, newer]).map((c) => c.secret);
+  const chips = buyerOrdersToAssign([older, newer]).flatMap((o) => o.tickets.map((t) => t.secret));
+  check("display order: rows are chronological by order, tickets by position", eq(rows, ["o1", "o2", "n1"]));
+  check("display order: chips follow the rows", eq(chips, rows));
+  check("display order: unchanged when the payload is reordered", eq(ticketChoices([newer, older]).map((c) => c.secret), rows));
   check("choices: other holders flagged", choices[1].sharedWith === 1 && choices[0].sharedWith === undefined);
   check("choices: admission tickets only, in order", eq(choices.map((c) => c.secret), ["s1", "s2", "fixture"]));
   check("choices: holder, add-ons and order carried", choices[0].holder === "Ada" && eq(choices[0].addons, ["Shirt - L"]) && choices[0].orderCode === "A");

--- a/event-app/scripts/test-qr-decode.ts
+++ b/event-app/scripts/test-qr-decode.ts
@@ -1,0 +1,80 @@
+// Decoder tests on synthetic screenshots. Run: pnpm qr:test
+import QRCode from "qrcode";
+import sharp from "sharp";
+import { decodeQr, type RgbaImage } from "../src/data/tickets/qrDecode";
+
+let failed = 0;
+const check = (label: string, ok: boolean, note = "") => {
+  if (!ok) failed++;
+  console.log(`${ok ? "PASS" : "FAIL"}  ${label}${note ? ` (${note})` : ""}`);
+};
+
+// 32 chars, like a Pretix position secret.
+const SECRET = "abcdefghijklmnopqrstuvwxyz012345";
+
+interface Shot {
+  width: number;
+  height: number;
+  qrSize: number;
+  left: number;
+  top: number;
+  dark?: boolean;
+}
+
+async function screenshot(opts: Shot): Promise<RgbaImage> {
+  const qr = await QRCode.toBuffer(SECRET, {
+    width: opts.qrSize,
+    margin: 2,
+    type: "png",
+    color: opts.dark ? { dark: "#ffffffff", light: "#000000ff" } : undefined,
+  });
+  const background = opts.dark
+    ? { r: 0, g: 0, b: 0, alpha: 1 }
+    : { r: 245, g: 241, b: 254, alpha: 1 };
+  const { data } = await sharp({
+    create: { width: opts.width, height: opts.height, channels: 4, background },
+  })
+    .composite([{ input: qr, left: opts.left, top: opts.top }])
+    .ensureAlpha()
+    .raw()
+    .toBuffer({ resolveWithObject: true });
+  return {
+    data: new Uint8ClampedArray(data.buffer, data.byteOffset, data.length),
+    width: opts.width,
+    height: opts.height,
+  };
+}
+
+function blank(width: number, height: number): RgbaImage {
+  const data = new Uint8ClampedArray(width * height * 4);
+  for (let i = 0; i < data.length; i += 4) {
+    data[i] = 240;
+    data[i + 1] = 240;
+    data[i + 2] = 240;
+    data[i + 3] = 255;
+  }
+  return { data, width, height };
+}
+
+const timed = (image: RgbaImage) => {
+  const t0 = Date.now();
+  const text = decodeQr(image);
+  return { text, ms: Date.now() - t0 };
+};
+
+async function main() {
+  let r = timed(await screenshot({ width: 1170, height: 2532, qrSize: 640, left: 265, top: 700 }));
+  check("phone screenshot, large QR", r.text === SECRET, `${r.ms} ms`);
+  r = timed(await screenshot({ width: 1170, height: 2532, qrSize: 180, left: 80, top: 1900 }));
+  check("phone screenshot, small QR in a corner (crop pass)", r.text === SECRET, `${r.ms} ms`);
+  r = timed(await screenshot({ width: 2560, height: 1440, qrSize: 420, left: 1500, top: 300 }));
+  check("desktop screenshot, downsampled", r.text === SECRET, `${r.ms} ms`);
+  r = timed(await screenshot({ width: 1170, height: 2532, qrSize: 500, left: 335, top: 900, dark: true }));
+  check("inverted colours (dark mode email)", r.text === SECRET, `${r.ms} ms`);
+  r = timed(blank(1170, 2532));
+  check("no code present", r.text === null, `${r.ms} ms`);
+  console.log(failed ? `\n${failed} check(s) failed` : "\nall checks passed");
+  process.exit(failed ? 1 : 0);
+}
+
+main();

--- a/event-app/src/app/api/interests/sync/route.ts
+++ b/event-app/src/app/api/interests/sync/route.ts
@@ -1,0 +1,53 @@
+import { NextRequest, NextResponse } from "next/server";
+import { requireUser } from "../../tickets/auth";
+import { createRateLimiter } from "../../tickets/rateLimit";
+import { serviceClient } from "../../serviceClient";
+import { parseSyncBody, type SyncResponse } from "@/data/interested/syncProtocol";
+
+/**
+ * Interests sync. The device posts its pending star changes and the cursor
+ * from its last sync; the `devcon8_interests_sync` function merges them
+ * last-write-wins per item and returns the account's changes since that
+ * cursor plus the new cursor. The user id comes from the verified session,
+ * never from the body.
+ */
+const perUser = createRateLimiter(120, 10 * 60_000);
+
+const fail = (error: string, status: number) =>
+  NextResponse.json({ success: false, error }, { status });
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireUser(request);
+    if (!user) return fail("Invalid or expired session", 401);
+    const db = serviceClient();
+    if (!db) return fail("Interests sync is not available right now", 503);
+    if (!perUser.allow(user.id)) return fail("Too many requests, try again in a few minutes", 429);
+
+    const body = parseSyncBody(await request.json().catch(() => null));
+    if (!body) return fail("Invalid sync request", 400);
+
+    const { data, error } = await db.rpc("devcon8_interests_sync", {
+      p_user_id: user.id,
+      p_event: body.event,
+      p_since: body.since === null ? null : new Date(body.since).toISOString(),
+      p_changes: body.changes.map((change) => ({
+        kind: change.kind,
+        item_id: change.id,
+        interested: change.interested,
+        updated_at: change.updatedAt,
+      })),
+    });
+    if (error) throw new Error(error.message);
+
+    const result = data as { changes?: SyncResponse["changes"]; now?: number } | null;
+    const payload: SyncResponse = {
+      changes: Array.isArray(result?.changes) ? result.changes : [],
+      now: typeof result?.now === "number" ? result.now : Date.now(),
+    };
+    return NextResponse.json({ success: true, data: payload });
+  } catch (err) {
+    console.error("[/api/interests/sync] error:", err);
+    return fail("Couldn't sync interests", 500);
+  }
+}

--- a/event-app/src/app/api/meerkat/route.ts
+++ b/event-app/src/app/api/meerkat/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import { getPaidTicketsByEmail, getStoreFromEnv } from "../tickets/pretix";
+import { listLinks } from "../tickets/links";
+import { getStoreFromEnv, getTicketsForUser } from "../tickets/pretix";
 import { generateHandoverToken } from "./verification";
 
 const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
@@ -11,8 +12,9 @@ const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
  *
  * Gated on two checks so we never hand a token to someone who shouldn't have
  * one: (1) a valid Supabase session, and (2) ownership of at least one paid
- * Pretix ticket for the configured event. The email baked into the JWT is the
- * verified session email — never client-supplied.
+ * Pretix ticket for the configured event, matched by email or attached by QR
+ * proof (see tickets/attach). The email baked into the JWT is the verified
+ * session email — never client-supplied.
  */
 export async function POST(request: NextRequest) {
   if (!supabaseUrl || !supabaseAnonKey) {
@@ -50,8 +52,13 @@ export async function POST(request: NextRequest) {
 
   let ownsTicket = false;
   try {
-    const orders = await getPaidTicketsByEmail(user.email, store);
-    ownsTicket = orders.some((order) => order.tickets.length > 0);
+    const { orders } = await getTicketsForUser(
+      { email: user.email, links: await listLinks(user.id, store.eventSlug) },
+      store
+    );
+    ownsTicket = orders.some((order) =>
+      order.tickets.some((ticket) => ticket.admission !== false)
+    );
   } catch (err) {
     console.error("[/api/meerkat] ticket lookup failed:", err);
     return NextResponse.json(

--- a/event-app/src/app/api/serviceClient.ts
+++ b/event-app/src/app/api/serviceClient.ts
@@ -1,0 +1,17 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+
+/**
+ * Lazily created Supabase client with the service-role key, for server routes
+ * that write tables behind RLS with no policies. Null when the key is not
+ * configured, so callers can answer 503 instead of crashing.
+ */
+let client: SupabaseClient | null | undefined;
+
+export function serviceClient(): SupabaseClient | null {
+  if (client === undefined) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    client = url && key ? createClient(url, key) : null;
+  }
+  return client;
+}

--- a/event-app/src/app/api/ticket-proof/route.ts
+++ b/event-app/src/app/api/ticket-proof/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { createClient } from "@supabase/supabase-js";
-import { getPaidTicketsByEmail, getStoreFromEnv } from "../tickets/pretix";
+import { listLinks } from "../tickets/links";
+import { getStoreFromEnv, getTicketsForUser } from "../tickets/pretix";
 import { getRequestOrigin } from "../_lib/origin";
 import {
   classifyTier,
@@ -107,8 +108,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // 3. Confirm the requested ticket is one of this user's event tickets.
-    const orders = await getPaidTicketsByEmail(user.email, store);
+    // 3. Confirm the requested ticket is one of this user's event tickets:
+    // matched by email or attached by proof (a QR-attached ticket is not
+    // under the account's email, yet its perk card is the one shown).
+    const { orders } = await getTicketsForUser(
+      { email: user.email, links: await listLinks(user.id, store.eventSlug) },
+      store
+    );
     const match = orders
       .flatMap((order) => order.tickets)
       .find((ticket) => ticket.secret === ticketSecret);

--- a/event-app/src/app/api/tickets/attach/route.ts
+++ b/event-app/src/app/api/tickets/attach/route.ts
@@ -1,0 +1,104 @@
+import { NextRequest, NextResponse } from "next/server";
+import { clientIp, requireUser } from "../auth";
+import { addLink, linksConfigured, removeLink } from "../links";
+import { ticketsPayload } from "../payload";
+import {
+  attachRejection,
+  getPaidTicketsByEmail,
+  getPositionBySecret,
+  getStoreFromEnv,
+  loadCatalog,
+} from "../pretix";
+import { createRateLimiter } from "../rateLimit";
+
+/**
+ * Attach a ticket the account holds. Two proofs:
+ * - `{ positionId }`: choosing among the tickets already matched by the
+ *   session email ("Which ticket is yours?"). The email match is the proof, so
+ *   the position only has to be one of those.
+ * - `{ code }`: the QR decoded from a screenshot, for a ticket not under this
+ *   email. Verified against Pretix (this event, paid order, live admission
+ *   position). Never log the code: it is the QR at the door.
+ * Either way the link is recorded and the refreshed tickets come back.
+ */
+
+/** Pretix position secrets are alphanumeric; anything else is not worth a lookup. */
+const CODE_SHAPE = /^[A-Za-z0-9_-]{8,256}$/;
+const INVALID = "This isn't a valid Devcon ticket";
+const TOO_MANY = "Too many attempts, try again in a few minutes";
+const UNAVAILABLE = "Ticket attach is not available right now";
+
+const WINDOW_MS = 10 * 60_000;
+const perUser = createRateLimiter(10, WINDOW_MS);
+const perIp = createRateLimiter(40, WINDOW_MS);
+
+const fail = (error: string, status: number) =>
+  NextResponse.json({ success: false, error }, { status });
+
+export async function POST(request: NextRequest) {
+  try {
+    const user = await requireUser(request);
+    if (!user) return fail("Invalid or expired session", 401);
+    const store = getStoreFromEnv();
+    if (!store || !linksConfigured()) return fail(UNAVAILABLE, 503);
+    if (!perUser.allow(user.id) || !perIp.allow(clientIp(request))) {
+      return fail(TOO_MANY, 429);
+    }
+
+    const body = await request.json().catch(() => null);
+
+    // Any non-zero integer: fixture tickets carry negative ids in dev, and the
+    // ownership check below decides either way.
+    const positionId = Number(body?.positionId);
+    if (Number.isInteger(positionId) && positionId !== 0) {
+      const mine = (await getPaidTicketsByEmail(user.email, store))
+        .flatMap((order) => order.tickets)
+        .find((ticket) => ticket.positionId === positionId && ticket.admission !== false);
+      if (!mine) return fail(INVALID, 422);
+      await addLink(user.id, store.eventSlug, positionId, mine.secret, "email");
+      return NextResponse.json(
+        { success: true, data: await ticketsPayload(user, store) },
+        { status: 201 }
+      );
+    }
+
+    const code = typeof body?.code === "string" ? body.code.trim() : "";
+    if (!CODE_SHAPE.test(code)) return fail(INVALID, 400);
+
+    const found = await getPositionBySecret(code, store);
+    if (!found) return fail(INVALID, 422);
+    const rejection = attachRejection(found.position, found.order, await loadCatalog(store));
+    if (rejection) return fail(rejection, 422);
+
+    await addLink(user.id, store.eventSlug, found.position.id, code, "qr");
+    return NextResponse.json(
+      { success: true, data: await ticketsPayload(user, store) },
+      { status: 201 }
+    );
+  } catch (err) {
+    console.error("[/api/tickets/attach] POST error:", err);
+    return fail("Couldn't attach the ticket, try again", 500);
+  }
+}
+
+/** Detach ("Wrong ticket?"): drop the link, return the remaining tickets. */
+export async function DELETE(request: NextRequest) {
+  try {
+    const user = await requireUser(request);
+    if (!user) return fail("Invalid or expired session", 401);
+    const store = getStoreFromEnv();
+    if (!store || !linksConfigured()) return fail(UNAVAILABLE, 503);
+
+    const body = await request.json().catch(() => null);
+    const positionId = Number(body?.positionId);
+    if (!Number.isInteger(positionId) || positionId === 0) {
+      return fail("Invalid ticket", 400);
+    }
+
+    await removeLink(user.id, store.eventSlug, positionId);
+    return NextResponse.json({ success: true, data: await ticketsPayload(user, store) });
+  } catch (err) {
+    console.error("[/api/tickets/attach] DELETE error:", err);
+    return fail("Couldn't remove the ticket, try again", 500);
+  }
+}

--- a/event-app/src/app/api/tickets/auth.ts
+++ b/event-app/src/app/api/tickets/auth.ts
@@ -1,0 +1,34 @@
+import type { NextRequest } from "next/server";
+import { createClient } from "@supabase/supabase-js";
+
+export interface AuthedUser {
+  id: string;
+  email: string;
+}
+
+/**
+ * The signed-in Supabase user behind a Bearer token, or null. The email is
+ * derived server-side from the verified session, never trusted from the
+ * client.
+ */
+export async function requireUser(request: NextRequest): Promise<AuthedUser | null> {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const anonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+  if (!url || !anonKey) return null;
+  const token = (request.headers.get("authorization") || "").replace(/^Bearer\s+/i, "");
+  if (!token) return null;
+  const {
+    data: { user },
+    error,
+  } = await createClient(url, anonKey).auth.getUser(token);
+  return error || !user?.email ? null : { id: user.id, email: user.email };
+}
+
+/** Best-effort client address for rate limiting (Netlify sets the first header). */
+export function clientIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-nf-client-connection-ip") ||
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "unknown"
+  );
+}

--- a/event-app/src/app/api/tickets/links.ts
+++ b/event-app/src/app/api/tickets/links.ts
@@ -1,0 +1,111 @@
+import { createHash } from "crypto";
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { LinkProof, TicketLink } from "./pretix";
+
+/**
+ * Attached tickets: positions an account proved it holds by uploading the
+ * ticket QR (see attach/route.ts). Server-only, service-role key; the table
+ * has RLS and no policies, so the anon key never reaches it. Migration:
+ * devcon-api/src/supabase/migrations/20260909120000_devcon8_ticket_links.sql.
+ */
+const TABLE = "devcon8_ticket_links";
+
+let client: SupabaseClient | null | undefined;
+function serviceClient(): SupabaseClient | null {
+  if (client === undefined) {
+    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+    client = url && key ? createClient(url, key) : null;
+  }
+  return client;
+}
+
+/** False when the service-role key is missing: reads return nothing, attach answers 503. */
+export function linksConfigured(): boolean {
+  return serviceClient() !== null;
+}
+
+/** Pretix secrets are long random strings, so a plain SHA-256 cannot be reversed or guessed. */
+export function hashSecret(secret: string): string {
+  return createHash("sha256").update(secret).digest("hex");
+}
+
+export async function listLinks(userId: string, event: string): Promise<TicketLink[]> {
+  const db = serviceClient();
+  if (!db) return [];
+  const { data, error } = await db
+    .from(TABLE)
+    .select("position_id, proof")
+    .eq("user_id", userId)
+    .eq("event", event)
+    .order("attached_at", { ascending: true });
+  if (error) throw new Error(error.message);
+  return (data ?? []).map((row) => ({
+    positionId: Number(row.position_id),
+    proof: row.proof === "email" ? "email" : "qr",
+  }));
+}
+
+export async function addLink(
+  userId: string,
+  event: string,
+  positionId: number,
+  secret: string,
+  proof: LinkProof
+): Promise<void> {
+  const db = serviceClient();
+  if (!db) throw new Error("Ticket links not configured");
+  const { error } = await db.from(TABLE).upsert(
+    { user_id: userId, event, position_id: positionId, secret_hash: hashSecret(secret), proof },
+    { onConflict: "user_id,event,position_id" }
+  );
+  if (error) throw new Error(error.message);
+}
+
+export async function removeLinks(
+  userId: string,
+  event: string,
+  positionIds: number[]
+): Promise<void> {
+  if (positionIds.length === 0) return;
+  const db = serviceClient();
+  if (!db) return;
+  const { error } = await db
+    .from(TABLE)
+    .delete()
+    .eq("user_id", userId)
+    .eq("event", event)
+    .in("position_id", positionIds);
+  if (error) throw new Error(error.message);
+}
+
+export const removeLink = (userId: string, event: string, positionId: number) =>
+  removeLinks(userId, event, [positionId]);
+
+/**
+ * How many other accounts attached each of these positions. Two accounts on
+ * one ticket is allowed (nothing here can arbitrate it, the door does), but
+ * the card says so. Returns only positions with at least one other holder.
+ */
+export async function countOtherHolders(
+  userId: string,
+  event: string,
+  positionIds: number[]
+): Promise<Map<number, number>> {
+  const counts = new Map<number, number>();
+  if (positionIds.length === 0) return counts;
+  const db = serviceClient();
+  if (!db) return counts;
+  const { data, error } = await db
+    .from(TABLE)
+    .select("position_id")
+    .eq("event", event)
+    .in("position_id", positionIds)
+    .neq("user_id", userId);
+  if (error) throw new Error(error.message);
+  for (const row of data ?? []) {
+    const id = Number(row.position_id);
+    counts.set(id, (counts.get(id) ?? 0) + 1);
+  }
+  return counts;
+}

--- a/event-app/src/app/api/tickets/payload.ts
+++ b/event-app/src/app/api/tickets/payload.ts
@@ -1,0 +1,52 @@
+import type { TicketsPayload } from "@/data/tickets/types";
+import type { AuthedUser } from "./auth";
+import { countOtherHolders, listLinks, removeLinks } from "./links";
+import { getTicketsForUser, type PretixStore } from "./pretix";
+
+/**
+ * Everything the account may see: attached tickets first, then email-matched
+ * ones, with attachments Pretix no longer verifies pruned on the way (the
+ * client shows a one-line notice from `removedAttachments`).
+ */
+export async function ticketsPayload(
+  user: AuthedUser,
+  store: PretixStore
+): Promise<TicketsPayload> {
+  // Links are best effort: a Supabase hiccup must not take the email-matched
+  // tickets down with it. Attach itself still reports its errors.
+  let links: Awaited<ReturnType<typeof listLinks>> = [];
+  try {
+    links = await listLinks(user.id, store.eventSlug);
+  } catch (err) {
+    console.warn("[/api/tickets] ticket links unavailable, email-matched only:", err);
+  }
+  const { orders, deadLinks } = await getTicketsForUser(
+    { email: user.email, links },
+    store
+  );
+  if (deadLinks.length > 0) {
+    try {
+      await removeLinks(user.id, store.eventSlug, deadLinks);
+    } catch (err) {
+      console.warn("[/api/tickets] could not remove dead ticket links:", err);
+    }
+  }
+  // Flag tickets another account also attached (best effort, informational).
+  try {
+    const positionIds = orders
+      .flatMap((order) => order.tickets.map((ticket) => ticket.positionId))
+      .filter((id): id is number => typeof id === "number");
+    const shared = await countOtherHolders(user.id, store.eventSlug, positionIds);
+    if (shared.size > 0) {
+      for (const order of orders) {
+        for (const ticket of order.tickets) {
+          const others = ticket.positionId !== undefined ? shared.get(ticket.positionId) : undefined;
+          if (others) ticket.sharedWith = others;
+        }
+      }
+    }
+  } catch (err) {
+    console.warn("[/api/tickets] could not count other holders:", err);
+  }
+  return { tickets: orders, removedAttachments: deadLinks.length || undefined };
+}

--- a/event-app/src/app/api/tickets/pretix.ts
+++ b/event-app/src/app/api/tickets/pretix.ts
@@ -471,6 +471,16 @@ export function isAttachablePosition(
 }
 
 /**
+ * What a Pretix lookup by id means for a link: "missing" (404) proves the
+ * position or order is gone and the link is dead; any other failure is
+ * Pretix's problem (429, 5xx, network) and must throw so nothing is deleted.
+ */
+export function pretixLookupOutcome(res: { ok: boolean; status: number }): "ok" | "missing" | "failed" {
+  if (res.ok) return "ok";
+  return res.status === 404 ? "missing" : "failed";
+}
+
+/**
  * Everything the account may see: attached positions first (flagged), then
  * email-matched orders. Each link is re-verified against Pretix: a position
  * that is gone, on an unpaid order, or canceled is reported in `deadLinks` so
@@ -488,13 +498,20 @@ export async function getTicketsForUser(
   const attachedRaw: Array<{ order: PretixOrder; positionId: number; proof: LinkProof }> = [];
 
   // Several attached positions can share an order; fetch each order once.
+  // Null only for a 404 (order gone): a transient Pretix error throws, so a
+  // 429 or 500 can never be mistaken for a dead link and delete it.
   const orderCache = new Map<string, Promise<PretixOrder | null>>();
   const fetchOrder = (code: string): Promise<PretixOrder | null> => {
     let pending = orderCache.get(code);
     if (!pending) {
       pending = fetch(`${baseFor(store)}/orders/${encodeURIComponent(code)}/`, {
         headers,
-      }).then((r) => (r.ok ? (r.json() as Promise<PretixOrder>) : null));
+      }).then((r) => {
+        const outcome = pretixLookupOutcome(r);
+        if (outcome === "missing") return null;
+        if (outcome === "failed") throw new Error(`Pretix API error: ${r.status}`);
+        return r.json() as Promise<PretixOrder>;
+      });
       orderCache.set(code, pending);
     }
     return pending;
@@ -510,11 +527,12 @@ export async function getTicketsForUser(
       const res = await fetch(`${baseFor(store)}/orderpositions/${positionId}/`, {
         headers,
       });
-      if (res.status === 404) {
+      const outcome = pretixLookupOutcome(res);
+      if (outcome === "missing") {
         deadLinks.push(positionId);
         return;
       }
-      if (!res.ok) throw new Error(`Pretix API error: ${res.status}`);
+      if (outcome === "failed") throw new Error(`Pretix API error: ${res.status}`);
       const position: PretixPosition = await res.json();
       const order = await fetchOrder(position.order);
       if (!order || !isAttachablePosition(position, order, itemsMap)) {

--- a/event-app/src/app/api/tickets/pretix.ts
+++ b/event-app/src/app/api/tickets/pretix.ts
@@ -1,6 +1,6 @@
-import type { Order, TicketStyle } from "@/data/tickets/types";
+import type { Order, Ticket, TicketAddon, TicketStyle } from "@/data/tickets/types";
 import { mirrorPicture } from "./pictures";
-import { applyFixture, parseFixture, resolveFixtureSwag } from "./testFixture";
+import { applyFixture, isFixturePositionId, parseFixture, resolveFixtureSwag } from "./testFixture";
 
 export interface PretixStore {
   url: string;
@@ -30,6 +30,98 @@ interface PretixItem {
   [key: string]: unknown;
 }
 
+/** The Pretix order-position fields this module reads; everything else stays `unknown`. */
+export interface PretixPosition {
+  id: number;
+  /** Order code. */
+  order: string;
+  /** Per-order position number, 1-based (printed on the ticket). */
+  positionid?: number;
+  item: number;
+  variation?: number | null;
+  price: string;
+  attendee_name?: string | null;
+  attendee_email?: string | null;
+  /** The QR payload. */
+  secret: string;
+  addon_to?: number | null;
+  checkins?: PretixCheckin[];
+  canceled?: boolean;
+  [key: string]: unknown;
+}
+
+/** One scan of a position against a check-in list. */
+export interface PretixCheckin {
+  /** Check-in list id. */
+  list?: number;
+  /** "entry" (default) or "exit". */
+  type?: string;
+  [key: string]: unknown;
+}
+
+export interface PretixOrder {
+  code: string;
+  /** "p" is paid. */
+  status: string;
+  email: string;
+  datetime: string;
+  /** Order page URL (carries the order secret). */
+  url?: string;
+  positions: PretixPosition[];
+  invoice_address?: { name?: string } | null;
+  [key: string]: unknown;
+}
+
+/** How an account proved it holds a ticket (see links.ts). */
+export type LinkProof = "email" | "qr";
+
+/** An attached ticket as stored for the account (see links.ts). */
+export interface TicketLink {
+  positionId: number;
+  /** Absent on rows from before the column existed; treated as "qr". */
+  proof?: LinkProof;
+}
+
+/**
+ * A ticket attached by QR proof may belong to an order someone else placed.
+ * Possession of the QR is the ticket, not the buyer's identity: strip the
+ * buyer's email and names from what the holder gets back (Pretix itself never
+ * reveals them from the secret alone), showing the holder as the account.
+ */
+export function redactBuyerIdentity(order: Order, accountEmail: string): Order {
+  const account = accountEmail.toLowerCase();
+  const tickets = order.tickets.map((ticket) =>
+    ticket.attendeeEmail.toLowerCase() === account
+      ? ticket
+      : {
+          ...ticket,
+          attendeeEmail: accountEmail,
+          attendeeName: null,
+          addons: ticket.addons.map((addon) => ({ ...addon, attendeeName: null })),
+        }
+  );
+  return {
+    ...order,
+    email: order.email.toLowerCase() === account ? order.email : accountEmail,
+    // The order page manages the whole order; never hand it to a QR holder.
+    url: order.email.toLowerCase() === account ? order.url : undefined,
+    tickets,
+  };
+}
+
+/**
+ * The email-ownership rule: a position belongs to `email` when its attendee
+ * email, or the order email when there is none, equals it. Used to select the
+ * email-matched tickets and to re-check links that were proven by that match.
+ */
+export function positionMatchesEmail(
+  position: { attendee_email?: string | null },
+  orderEmail: string | null | undefined,
+  email: string
+): boolean {
+  return (position.attendee_email || orderEmail || "").toLowerCase() === email.toLowerCase();
+}
+
 /** Build the Pretix store from env. Returns null if not configured. */
 export function getStoreFromEnv(): PretixStore | null {
   const apiKey = process.env.PRETIX_API_KEY;
@@ -45,6 +137,14 @@ export function getStoreFromEnv(): PretixStore | null {
     apiKey,
   };
 }
+
+const headersFor = (store: PretixStore) => ({
+  Authorization: `Token ${store.apiKey}`,
+  "Content-Type": "application/json",
+});
+
+const baseFor = (store: PretixStore) =>
+  `${store.url}/api/v1/organizers/${store.organizerSlug}/events/${store.eventSlug}`;
 
 const localized = (
   value: string | { en: string; [key: string]: string } | undefined
@@ -93,163 +193,394 @@ function getVariationValue(
 }
 
 /**
- * Fetch paid Pretix orders for an email and normalize them into Orders.
- * Ported from devconnect-app's getPaidTicketsByEmail, generalized to a single
- * configurable store.
+ * Whether a swag position was handed over: Pretix only records a check-in
+ * against a list that includes the position's product, so any entry-type
+ * check-in on a swag position means it was scanned at a pickup point. Exit
+ * scans never count. No configuration needed.
  */
-export async function getPaidTicketsByEmail(
-  email: string,
-  store: PretixStore
-): Promise<Order[]> {
-  if (!store.apiKey) throw new Error("PRETIX_API_KEY is missing");
+export function positionCollected(position: { checkins?: PretixCheckin[] }): boolean {
+  return (position.checkins ?? []).some((checkin) => (checkin.type ?? "entry") === "entry");
+}
 
-  const headers = {
-    Authorization: `Token ${store.apiKey}`,
-    "Content-Type": "application/json",
-  };
-  const base = `${store.url}/api/v1/organizers/${store.organizerSlug}/events/${store.eventSlug}`;
-
-  // Item catalog (product names, variations) — changes rarely, so cache it.
-  const itemsResponse = await fetch(`${base}/items/`, {
-    headers,
+/** Item catalog (product names, variations, photos). Changes rarely, so cached an hour. */
+export async function loadCatalog(store: PretixStore): Promise<Map<number, PretixItem>> {
+  const res = await fetch(`${baseFor(store)}/items/`, {
+    headers: headersFor(store),
     next: { revalidate: 3600 },
   });
-  if (!itemsResponse.ok) {
-    throw new Error(`Failed to fetch items: ${itemsResponse.status}`);
-  }
-  const itemsData = await itemsResponse.json();
-  const itemsMap = new Map<number, PretixItem>(
-    (itemsData.results ?? []).map((item: PretixItem) => [item.id, item])
+  if (!res.ok) throw new Error(`Failed to fetch items: ${res.status}`);
+  const data = await res.json();
+  return new Map<number, PretixItem>(
+    (data.results ?? []).map((item: PretixItem) => [item.id, item])
   );
+}
 
-  // Paid orders matching this email.
-  const params = new URLSearchParams({ status: "p", search: email });
-  const response = await fetch(`${base}/orders?${params}`, { headers });
-  if (!response.ok) {
-    throw new Error(`Pretix API error: ${response.status}`);
-  }
-  const data = await response.json();
-  const orders = data.results ?? [];
+type PictureUrl = (picture: string | null | undefined) => string | undefined;
 
-  // Product photos for this user's positions, mirrored into Storage so the
-  // swag cards work offline (see pictures.ts). Keyed by source URL.
-  const sources = new Set<string>();
+/**
+ * Product photos for every position in `orders` (plus `extra` sources),
+ * mirrored into Storage so the swag cards work offline (see pictures.ts).
+ * Returns the resolver from a Pretix `picture` to the URL the client loads.
+ */
+async function resolvePictures(
+  orders: PretixOrder[],
+  itemsMap: Map<number, PretixItem>,
+  extra: Iterable<string>
+): Promise<PictureUrl> {
+  const sources = new Set<string>(extra);
   for (const order of orders) {
     for (const p of order.positions ?? []) {
       const picture = itemsMap.get(p.item)?.picture;
       if (picture) sources.add(picture);
     }
   }
-  // Test fixture (see testFixture.ts): mirror the swag photos it borrows too.
-  const fixture = parseFixture(process.env.TICKET_TEST_INDIA_ORDER_CODE);
-  const fixtureSwag = resolveFixtureSwag(
-    [...itemsMap.values()].map((item) => ({
-      name: localized(item.name) ?? "",
-      picture: item.picture,
-    }))
-  );
-  if (fixture.length > 0) {
-    for (const swag of [fixtureSwag.shirt, fixtureSwag.chessSet]) {
-      if (swag.picture) sources.add(swag.picture);
-    }
-  }
   const pictures = new Map<string, string>();
   await Promise.all(
     [...sources].map(async (src) => pictures.set(src, await mirrorPicture(src)))
   );
-  const pictureUrl = (picture: string | null | undefined) =>
-    picture ? (pictures.get(picture) ?? picture) : undefined;
+  return (picture) => (picture ? (pictures.get(picture) ?? picture) : undefined);
+}
+
+/**
+ * Normalise one Pretix order into an `Order`, keeping only the positions
+ * `keep` accepts (email ownership for the search path, one position id for an
+ * attached ticket). Add-ons follow their parent position. Canceled positions
+ * (refunded, reissued) are dropped: their QR no longer opens the door.
+ */
+function normalizeOrder(
+  order: PretixOrder,
+  opts: {
+    itemsMap: Map<number, PretixItem>;
+    pictureUrl: PictureUrl;
+    store: PretixStore;
+    keep: (position: PretixPosition) => boolean;
+    attached?: boolean;
+    /** The signed-in email: the order page URL is exposed only to the buyer. */
+    accountEmail: string;
+  }
+): Order {
+  const { itemsMap, pictureUrl, store } = opts;
+  const isBuyer = (order.email || "").toLowerCase() === opts.accountEmail.toLowerCase();
+  const positions = order.positions ?? [];
+
+  const tickets = positions
+    .filter((p) => !p.addon_to && !p.canceled && opts.keep(p))
+    .map((position): Ticket => {
+      const mainItem = itemsMap.get(position.item);
+
+      const addons = positions
+        .filter((p) => p.addon_to === position.id && !p.canceled)
+        .map((addon): TicketAddon => {
+          const itemDetails = itemsMap.get(addon.item);
+          const variationValue = getVariationValue(
+            { variation: addon.variation ?? undefined },
+            itemDetails
+          );
+          let itemName = localized(itemDetails?.name) || `Item ${addon.item}`;
+          if (variationValue) itemName = `${itemName} - ${variationValue}`;
+
+          return {
+            id: addon.item,
+            secret: addon.secret,
+            itemName,
+            description: localized(itemDetails?.description),
+            price: addon.price,
+            attendeeName: addon.attendee_name ?? null,
+            category: itemDetails?.category,
+            active: itemDetails?.active,
+            imageUrl: pictureUrl(itemDetails?.picture),
+            collected: positionCollected(addon) || undefined,
+          };
+        });
+
+      const checkins = Array.isArray(position.checkins) ? position.checkins : [];
+
+      // Devcon's Pretix checkout doesn't collect per-attendee names, so
+      // `attendee_name` is usually null. Fall back to the order's
+      // invoice/billing name before the UI's last-resort email fallback,
+      // but only for the buyer's own position: a gifted ticket (attendee
+      // email differs from the order email) must not show the buyer's name
+      // to its holder.
+      const isBuyersOwn =
+        !position.attendee_email ||
+        position.attendee_email.toLowerCase() === (order.email || "").toLowerCase();
+
+      return {
+        secret: position.secret,
+        attendeeName:
+          position.attendee_name ||
+          (isBuyersOwn ? order.invoice_address?.name : null) ||
+          null,
+        attendeeEmail: position.attendee_email || order.email,
+        price: position.price,
+        itemId: position.item,
+        itemName:
+          localized(mainItem?.name) ||
+          (position.item_name as string | undefined) ||
+          "Ticket",
+        itemDescription: localized(mainItem?.description),
+        // Tri-state on purpose: an item the catalog lookup could not resolve
+        // stays undefined (client treats it as a ticket), never `false`.
+        admission: mainItem ? mainItem.admission === true : undefined,
+        addons,
+        hasCheckedIn: checkins.length > 0,
+        imageUrl: pictureUrl(mainItem?.picture),
+        style: styleForItem(position.item),
+        positionId: position.id,
+        positionNumber: position.positionid,
+        // Absent (not false) on email-matched tickets, so the cached payload
+        // shape does not grow for the common case.
+        attached: opts.attached || undefined,
+      };
+    });
+
+  return {
+    orderCode: order.code,
+    orderDate: order.datetime,
+    email: order.email,
+    url: isBuyer && order.url ? order.url : undefined,
+    eventName: store.eventName,
+    eventSlug: store.eventSlug,
+    eventId: store.eventId ?? null,
+    tickets,
+  };
+}
+
+/** The dev/preview test fixture (see testFixture.ts), resolved against the catalog. */
+function fixtureContext(catalog: Map<number, PretixItem>) {
+  const fixture = parseFixture(process.env.TICKET_TEST_INDIA_ORDER_CODE);
+  const swag = resolveFixtureSwag(
+    [...catalog.values()].map((item) => ({
+      name: localized(item.name) ?? "",
+      picture: item.picture,
+    }))
+  );
+  const pictures =
+    fixture.length > 0
+      ? [swag.shirt.picture, swag.chessSet.picture].filter(
+          (picture): picture is string => !!picture
+        )
+      : [];
+  return { fixture, swag, pictures };
+}
+
+/**
+ * Fetch paid Pretix orders for an email and normalize them into Orders.
+ * Ported from devconnect-app's getPaidTicketsByEmail, generalized to a single
+ * configurable store. `itemsMap` can be passed by callers that already loaded
+ * the catalog. The test fixture is applied unless the caller merges these
+ * orders with attached ones first and applies it itself (getTicketsForUser).
+ */
+export async function getPaidTicketsByEmail(
+  email: string,
+  store: PretixStore,
+  itemsMap?: Map<number, PretixItem>,
+  { withFixture = true }: { withFixture?: boolean } = {}
+): Promise<Order[]> {
+  if (!store.apiKey) throw new Error("PRETIX_API_KEY is missing");
+  const catalog = itemsMap ?? (await loadCatalog(store));
+
+  // Paid orders matching this email.
+  const params = new URLSearchParams({ status: "p", search: email });
+  const response = await fetch(`${baseFor(store)}/orders?${params}`, {
+    headers: headersFor(store),
+  });
+  if (!response.ok) {
+    throw new Error(`Pretix API error: ${response.status}`);
+  }
+  const data = await response.json();
+  const orders: PretixOrder[] = data.results ?? [];
+
+  // Test fixture (see testFixture.ts): mirror the swag photos it borrows too.
+  const fx = fixtureContext(catalog);
+  const pictureUrl = await resolvePictures(orders, catalog, fx.pictures);
 
   // SECURITY: Pretix `search` matches orders by contact email too, so an order
   // can contain positions assigned to OTHER attendees. The signed-in user must
   // only ever get their OWN tickets — keep only positions whose attendee email
   // (falling back to the order email) equals the authenticated email.
-  const wanted = email.toLowerCase();
-  const ownedByUser = (p: any, orderEmail: string) =>
-    (p.attendee_email || orderEmail || "").toLowerCase() === wanted;
-
   const result = orders
-    .map((order: any): Order => {
-      // Real tickets are non-add-on positions assigned to the signed-in user.
-      const ticketPositions = order.positions.filter(
-        (p: any) => !p.addon_to && ownedByUser(p, order.email)
-      );
+    .map((order) =>
+      normalizeOrder(order, {
+        itemsMap: catalog,
+        pictureUrl,
+        store,
+        keep: (p) => positionMatchesEmail(p, order.email, email),
+        accountEmail: email,
+      })
+    )
+    .filter((order) => order.tickets.length > 0);
 
-      const tickets = ticketPositions.map((position: any) => {
-        const mainItem = itemsMap.get(position.item);
-
-        const addons = order.positions
-          .filter((p: any) => p.addon_to === position.id)
-          .map((addon: any) => {
-            const itemDetails = itemsMap.get(addon.item);
-            const variationValue = getVariationValue(addon, itemDetails);
-            let itemName =
-              localized(itemDetails?.name) || `Item ${addon.item}`;
-            if (variationValue) itemName = `${itemName} - ${variationValue}`;
-
-            return {
-              id: addon.item,
-              secret: addon.secret,
-              itemName,
-              description: localized(itemDetails?.description),
-              price: addon.price,
-              attendeeName: addon.attendee_name,
-              category: itemDetails?.category,
-              active: itemDetails?.active,
-              imageUrl: pictureUrl(itemDetails?.picture),
-            };
-          });
-
-        const checkins = Array.isArray(position.checkins)
-          ? position.checkins
-          : [];
-
-        // Devcon's Pretix checkout doesn't collect per-attendee names, so
-        // `attendee_name` is usually null. Fall back to the order's
-        // invoice/billing name before the UI's last-resort email fallback,
-        // but only for the buyer's own position: a gifted ticket (attendee
-        // email differs from the order email) must not show the buyer's name
-        // to its holder.
-        const isBuyersOwn =
-          !position.attendee_email ||
-          position.attendee_email.toLowerCase() ===
-            (order.email || "").toLowerCase();
-
-        return {
-          secret: position.secret,
-          attendeeName:
-            position.attendee_name ||
-            (isBuyersOwn ? order.invoice_address?.name : null) ||
-            null,
-          attendeeEmail: position.attendee_email || order.email,
-          price: position.price,
-          itemId: position.item,
-          itemName:
-            localized(mainItem?.name) || position.item_name || "Ticket",
-          itemDescription: localized(mainItem?.description),
-          // Tri-state on purpose: an item the catalog lookup could not resolve
-          // stays undefined (client treats it as a ticket), never `false`.
-          admission: mainItem ? mainItem.admission === true : undefined,
-          addons,
-          hasCheckedIn: checkins.length > 0,
-          imageUrl: pictureUrl(mainItem?.picture),
-          style: styleForItem(position.item),
-        };
-      });
-
-      return {
-        orderCode: order.code,
-        orderDate: order.datetime,
-        email: order.email,
-        eventName: store.eventName,
-        eventSlug: store.eventSlug,
-        eventId: store.eventId ?? null,
-        tickets,
-      };
-    })
-    .filter((order: Order) => order.tickets.length > 0);
-
-  applyFixture(result, { fixture, email, swag: fixtureSwag, pictureUrl });
+  if (withFixture) {
+    applyFixture(result, { fixture: fx.fixture, email, swag: fx.swag, pictureUrl });
+  }
 
   return result;
+}
+
+/**
+ * The position a ticket QR encodes, with its order. Pretix filters
+ * `orderpositions` by exact secret; the event is fixed by the URL, so a code
+ * from another event simply returns nothing.
+ */
+export async function getPositionBySecret(
+  secret: string,
+  store: PretixStore
+): Promise<{ position: PretixPosition; order: PretixOrder } | null> {
+  const headers = headersFor(store);
+  const res = await fetch(
+    `${baseFor(store)}/orderpositions/?secret=${encodeURIComponent(secret)}`,
+    { headers }
+  );
+  if (!res.ok) throw new Error(`Pretix API error: ${res.status}`);
+  const position: PretixPosition | undefined = (await res.json()).results?.[0];
+  if (!position) return null;
+  const orderRes = await fetch(
+    `${baseFor(store)}/orders/${encodeURIComponent(position.order)}/`,
+    { headers }
+  );
+  if (!orderRes.ok) throw new Error(`Pretix API error: ${orderRes.status}`);
+  return { position, order: await orderRes.json() };
+}
+
+/**
+ * Why a position cannot be attached, as the message the holder sees, or null
+ * when it can (paid order, live, a real ticket: not an add-on, not
+ * merchandise). Codes are unguessable, so naming the reason leaks nothing.
+ */
+export function attachRejection(
+  position: PretixPosition,
+  order: PretixOrder,
+  itemsMap: Map<number, PretixItem>
+): string | null {
+  if (position.addon_to || itemsMap.get(position.item)?.admission === false) {
+    return "That's a swag QR code, not a ticket";
+  }
+  if (position.canceled) return "This ticket was canceled in Pretix";
+  if (order.status !== "p") return "This ticket's order isn't paid yet";
+  return null;
+}
+
+/** A position someone may attach: paid order, live, a real ticket (not an add-on, not merchandise). */
+export function isAttachablePosition(
+  position: PretixPosition,
+  order: PretixOrder,
+  itemsMap: Map<number, PretixItem>
+): boolean {
+  return attachRejection(position, order, itemsMap) === null;
+}
+
+/**
+ * Everything the account may see: attached positions first (flagged), then
+ * email-matched orders. Each link is re-verified against Pretix: a position
+ * that is gone, on an unpaid order, or canceled is reported in `deadLinks` so
+ * the caller can remove it, and so is an email-proof link whose position no
+ * longer carries the account's email (the buyer reassigned that ticket to its
+ * holder). A ticket both attached and email-matched appears once, as attached.
+ */
+export async function getTicketsForUser(
+  opts: { email: string; links: TicketLink[] },
+  store: PretixStore
+): Promise<{ orders: Order[]; deadLinks: number[] }> {
+  const itemsMap = await loadCatalog(store);
+  const headers = headersFor(store);
+  const deadLinks: number[] = [];
+  const attachedRaw: Array<{ order: PretixOrder; positionId: number; proof: LinkProof }> = [];
+
+  // Several attached positions can share an order; fetch each order once.
+  const orderCache = new Map<string, Promise<PretixOrder | null>>();
+  const fetchOrder = (code: string): Promise<PretixOrder | null> => {
+    let pending = orderCache.get(code);
+    if (!pending) {
+      pending = fetch(`${baseFor(store)}/orders/${encodeURIComponent(code)}/`, {
+        headers,
+      }).then((r) => (r.ok ? (r.json() as Promise<PretixOrder>) : null));
+      orderCache.set(code, pending);
+    }
+    return pending;
+  };
+
+  // Fixture tickets (dev/preview) carry negative ids: no Pretix lookup, they
+  // are marked attached once the fixture has been applied below.
+  const fixtureLinks = opts.links.filter((link) => isFixturePositionId(link.positionId));
+  const realLinks = opts.links.filter((link) => !isFixturePositionId(link.positionId));
+
+  await Promise.all(
+    realLinks.map(async ({ positionId, proof }) => {
+      const res = await fetch(`${baseFor(store)}/orderpositions/${positionId}/`, {
+        headers,
+      });
+      if (res.status === 404) {
+        deadLinks.push(positionId);
+        return;
+      }
+      if (!res.ok) throw new Error(`Pretix API error: ${res.status}`);
+      const position: PretixPosition = await res.json();
+      const order = await fetchOrder(position.order);
+      if (!order || !isAttachablePosition(position, order, itemsMap)) {
+        deadLinks.push(positionId);
+        return;
+      }
+      if (proof === "email" && !positionMatchesEmail(position, order.email, opts.email)) {
+        deadLinks.push(positionId);
+        return;
+      }
+      attachedRaw.push({ order, positionId, proof: proof ?? "qr" });
+    })
+  );
+
+  const emailOrders = await getPaidTicketsByEmail(opts.email, store, itemsMap, {
+    withFixture: false,
+  });
+  const fx = fixtureContext(itemsMap);
+  const pictureUrl = await resolvePictures(
+    attachedRaw.map((entry) => entry.order),
+    itemsMap,
+    fx.pictures
+  );
+  const attachedOrders = attachedRaw
+    .sort((a, b) => a.positionId - b.positionId)
+    .map(({ order, positionId, proof }) => {
+      const normalized = normalizeOrder(order, {
+        itemsMap,
+        pictureUrl,
+        store,
+        keep: (p) => p.id === positionId,
+        attached: true,
+        accountEmail: opts.email,
+      });
+      return proof === "qr" ? redactBuyerIdentity(normalized, opts.email) : normalized;
+    })
+    .filter((order) => order.tickets.length > 0);
+
+  const attachedSecrets = new Set(
+    attachedOrders.flatMap((order) => order.tickets.map((ticket) => ticket.secret))
+  );
+  const rest = emailOrders
+    .map((order) => ({
+      ...order,
+      tickets: order.tickets.filter((ticket) => !attachedSecrets.has(ticket.secret)),
+    }))
+    .filter((order) => order.tickets.length > 0);
+
+  const orders = [...attachedOrders, ...rest];
+  // Applied after the merge, so the fixture lands on the copy of the real
+  // ticket that is actually returned (the attached one once it is chosen).
+  applyFixture(orders, { fixture: fx.fixture, email: opts.email, swag: fx.swag, pictureUrl });
+  for (const { positionId } of fixtureLinks) {
+    const holder = orders.find((order) =>
+      order.tickets.some((ticket) => ticket.positionId === positionId)
+    );
+    if (!holder) {
+      deadLinks.push(positionId);
+      continue;
+    }
+    for (const ticket of holder.tickets) {
+      if (ticket.positionId === positionId) ticket.attached = true;
+    }
+    // Attached first, like a real one, so it becomes the primary.
+    orders.splice(orders.indexOf(holder), 1);
+    orders.unshift(holder);
+  }
+  return { orders, deadLinks };
 }

--- a/event-app/src/app/api/tickets/rateLimit.ts
+++ b/event-app/src/app/api/tickets/rateLimit.ts
@@ -1,0 +1,36 @@
+/**
+ * Sliding-window limiter kept in memory. Per serverless instance, so it bounds
+ * bursts against one warm function rather than the whole fleet; enough here,
+ * since a wrong code cannot be brute-forced (Pretix secrets are long random
+ * strings) and each attempt costs one Pretix lookup.
+ */
+export interface RateLimiter {
+  allow(key: string): boolean;
+}
+
+export function createRateLimiter(
+  max: number,
+  windowMs: number,
+  now: () => number = Date.now
+): RateLimiter {
+  const hits = new Map<string, number[]>();
+  return {
+    allow(key) {
+      const t = now();
+      const cutoff = t - windowMs;
+      const recent = (hits.get(key) ?? []).filter((stamp) => stamp > cutoff);
+      if (recent.length >= max) {
+        hits.set(key, recent);
+        return false;
+      }
+      recent.push(t);
+      hits.set(key, recent);
+      if (hits.size > 5000) {
+        for (const [k, stamps] of hits) {
+          if (stamps.every((stamp) => stamp <= cutoff)) hits.delete(k);
+        }
+      }
+      return true;
+    },
+  };
+}

--- a/event-app/src/app/api/tickets/route.ts
+++ b/event-app/src/app/api/tickets/route.ts
@@ -1,37 +1,23 @@
 import { NextRequest, NextResponse } from "next/server";
-import { createClient } from "@supabase/supabase-js";
-import { getPaidTicketsByEmail, getStoreFromEnv } from "./pretix";
+import { requireUser } from "./auth";
+import { ticketsPayload } from "./payload";
+import { getStoreFromEnv } from "./pretix";
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
-
+/**
+ * The signed-in user's tickets: positions the account attached by QR proof
+ * (first, flagged) plus paid tickets matched by the session email.
+ */
 export async function GET(request: NextRequest) {
   try {
-    if (!supabaseUrl || !supabaseAnonKey) {
+    if (!process.env.NEXT_PUBLIC_SUPABASE_URL || !process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) {
       return NextResponse.json(
         { success: false, error: "Auth not configured" },
         { status: 500 }
       );
     }
 
-    // Verify the Supabase access token and derive the email server-side.
-    const token = (request.headers.get("authorization") || "").replace(
-      /^Bearer\s+/i,
-      ""
-    );
-    if (!token) {
-      return NextResponse.json(
-        { success: false, error: "Missing auth token" },
-        { status: 401 }
-      );
-    }
-
-    const supabase = createClient(supabaseUrl, supabaseAnonKey);
-    const {
-      data: { user },
-      error: authError,
-    } = await supabase.auth.getUser(token);
-    if (authError || !user?.email) {
+    const user = await requireUser(request);
+    if (!user) {
       return NextResponse.json(
         { success: false, error: "Invalid or expired session" },
         { status: 401 }
@@ -45,8 +31,7 @@ export async function GET(request: NextRequest) {
       return NextResponse.json({ success: true, data: { tickets: [] } });
     }
 
-    const tickets = await getPaidTicketsByEmail(user.email, store);
-    return NextResponse.json({ success: true, data: { tickets } });
+    return NextResponse.json({ success: true, data: await ticketsPayload(user, store) });
   } catch (err) {
     console.error("[/api/tickets] error:", err);
     return NextResponse.json(

--- a/event-app/src/app/api/tickets/testFixture.ts
+++ b/event-app/src/app/api/tickets/testFixture.ts
@@ -1,17 +1,21 @@
-import type { Order, Ticket, TicketAddon } from "@/data/tickets/types";
+import type { Order, Ticket } from "@/data/tickets/types";
 
 /**
  * Test fixture for the signed-in ticket UI, enabled per environment through
  * TICKET_TEST_INDIA_ORDER_CODE (order codes never live in source). Syntax:
  * "CODE" or "CODE:N", comma-separated for several orders.
  *
- * Each listed order that belongs to the signed-in user gets:
+ * Each listed order that belongs to the signed-in user spawns a separate fake
+ * order, coded `TEST-<code>` so it can never be mistaken for a real one, with:
  * - N fake India Resident admission tickets (tier "india" for the ENS proof
  *   flow: classifyTier keys off the flag emoji in the name), exercising the
  *   multi-ticket layout when N > 1;
- * - a fake t-shirt add-on on the first of them, and a fake standalone Chess
- *   Set position, covering both swag code paths (add-on vs. merchandise sold
- *   as its own position).
+ * - two fake add-ons on the first of them: a t-shirt, and a Chess Set marked
+ *   collected to show the swag pickup state. All real swag is sold as add-ons
+ *   too, so there is no standalone merchandise in the fixture. Fixture tickets
+ *   carry synthetic negative position ids so they can be chosen like a real
+ *   ticket (the server skips Pretix for those), which is how the fixture
+ *   swag and the India card get previewed.
  *
  * Swag borrows the real catalog item's name and photo when one matches, so the
  * cards look like production. Fake secrets never resolve in Pretix, so their
@@ -22,6 +26,13 @@ export interface FixtureOrder {
   code: string;
   count: number;
 }
+
+/** Negative position ids for fixture tickets: unique per fixture order and ticket, never a Pretix id. */
+export function fixturePositionId(fixtureIndex: number, ticketNumber: number): number {
+  return -(fixtureIndex * 100 + ticketNumber);
+}
+
+export const isFixturePositionId = (positionId: number): boolean => positionId < 0;
 
 export function parseFixture(raw: string | undefined): FixtureOrder[] {
   return (raw ?? "")
@@ -87,24 +98,25 @@ export function applyFixture(
     pictureUrl: (picture: string | null | undefined) => string | undefined;
   }
 ): void {
-  for (const { code, count } of opts.fixture) {
+  for (const [fixtureIndex, { code, count }] of opts.fixture.entries()) {
     const order = orders.find((entry) => entry.orderCode === code);
     if (!order) continue;
     const tag = code.toLowerCase();
     const holder = order.tickets[0]?.attendeeName ?? null;
+    // Own order, own code: the fake tickets must not read as part of the real
+    // order (and the fake code keeps them out of anything keyed by order).
+    const fake: Order = {
+      orderCode: `TEST-${code}`,
+      orderDate: order.orderDate,
+      email: order.email,
+      eventName: order.eventName,
+      eventSlug: order.eventSlug,
+      eventId: order.eventId,
+      tickets: [],
+    };
+    orders.push(fake);
 
     for (let i = 1; i <= count; i++) {
-      const addons: TicketAddon[] = [];
-      if (i === 1) {
-        addons.push({
-          id: 999998,
-          secret: `test-shirt-${tag}`,
-          itemName: opts.swag.shirt.name,
-          price: "0.00",
-          attendeeName: holder,
-          imageUrl: opts.pictureUrl(opts.swag.shirt.picture),
-        });
-      }
       const ticket: Ticket = {
         secret: `test-india-resident-${tag}-${i}`,
         attendeeName: holder,
@@ -114,23 +126,40 @@ export function applyFixture(
         itemName: "India Resident \u{1F1EE}\u{1F1F3}",
         itemDescription: "Test ticket for the ENS proof flow",
         admission: true,
-        addons,
+        addons: [],
         hasCheckedIn: false,
+        test: true,
+        // Synthetic, negative: choosable like a real ticket in dev, never a
+        // Pretix id (see getTicketsForUser, which skips Pretix for these).
+        positionId: fixturePositionId(fixtureIndex, i),
+        positionNumber: i,
       };
-      order.tickets.push(ticket);
+      if (i === 1) {
+        // Both fake swag items ride on the first fake ticket, which can be
+        // chosen like a real one, so the swag shelf can be previewed.
+        ticket.addons.push(
+          {
+            id: 999998,
+            secret: `test-shirt-${tag}`,
+            itemName: opts.swag.shirt.name,
+            price: "0.00",
+            attendeeName: holder,
+            imageUrl: opts.pictureUrl(opts.swag.shirt.picture),
+          },
+          {
+            id: 999997,
+            secret: `test-chess-set-${tag}`,
+            itemName: opts.swag.chessSet.name,
+            price: "0.00",
+            attendeeName: holder,
+            imageUrl: opts.pictureUrl(opts.swag.chessSet.picture),
+            // Shows the swag pickup state; the shirt stays unclaimed.
+            collected: true,
+          }
+        );
+      }
+      fake.tickets.push(ticket);
     }
 
-    order.tickets.push({
-      secret: `test-chess-set-${tag}`,
-      attendeeName: holder,
-      attendeeEmail: opts.email,
-      price: "0.00",
-      itemId: 999997,
-      itemName: opts.swag.chessSet.name,
-      admission: false,
-      addons: [],
-      hasCheckedIn: false,
-      imageUrl: opts.pictureUrl(opts.swag.chessSet.picture),
-    });
   }
 }

--- a/event-app/src/app/layout.tsx
+++ b/event-app/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { DataProvider } from "@/data/cache";
 import { UserProvider } from "@/data/auth/useUser";
 import { CacheWarmer } from "@/components/CacheWarmer";
+import { InterestSync } from "@/data/interested/InterestSync";
 import { IOSViewportHealer } from "@/components/IOSViewportHealer";
 import { Toaster } from "sonner";
 import { BadgeCheck, CircleAlert } from "lucide-react";
@@ -211,6 +212,7 @@ export default function RootLayout({
         <DataProvider>
           <UserProvider>
             <CacheWarmer />
+            <InterestSync />
             {children}
           </UserProvider>
         </DataProvider>

--- a/event-app/src/components/MyTickets.tsx
+++ b/event-app/src/components/MyTickets.tsx
@@ -1,42 +1,154 @@
 "use client";
 
+import { useState } from "react";
+import { toast } from "sonner";
 import { useTickets } from "@/data/tickets/useTickets";
+import { useUser } from "@/data/auth/useUser";
+import { buyerOrdersToAssign, ticketChoices } from "@/data/tickets/primary";
+import { BuyerOrdersHint } from "./ticket/BuyerOrdersHint";
 import { useOnline } from "@/hooks/useOnline";
+import { AttachTicketCard, ChooseTicketCard } from "./ticket/AttachTicketCard";
 import {
   RefreshTicketsButton,
   TicketSectionHeader,
   TicketSections,
 } from "./ticket/TicketSections";
 
+const purchaseLink = (
+  <p className="text-sm text-dc-muted">
+    Don&apos;t have a ticket yet?{" "}
+    <a
+      href="https://devcon.org/tickets"
+      target="_blank"
+      rel="noopener noreferrer"
+      className="font-bold text-dc-purple underline-offset-2 hover:underline"
+    >
+      Get tickets ↗
+    </a>
+  </p>
+);
+
 /**
  * Signed-in body of the ticket page (Figma "My Devcon"): loading/error/empty
- * states around the shared TicketSections layout (also used on the home page).
+ * states around the shared TicketSections layout (also used on the home page),
+ * plus the two "which ticket is yours" prompts (spec: ticket identity design).
+ * Several tickets under the email: a select, and no QR codes until one is
+ * chosen. None: the screenshot upload instead of an empty state.
  */
 export function MyTickets() {
-  const { tickets, qrCodes, isLoading, isRefreshing, error, refresh } =
-    useTickets();
+  const { user } = useUser();
+  const {
+    tickets,
+    qrCodes,
+    primary,
+    prompt,
+    removedAttachments,
+    attach,
+    choose,
+    detach,
+    isLoading,
+    isRefreshing,
+    error,
+    refresh,
+  } = useTickets();
   const online = useOnline();
+  const [replacing, setReplacing] = useState(false);
+  const buyerOrders = buyerOrdersToAssign(tickets);
+
+  const attachAndClose = async (code: string) => {
+    const result = await attach(code);
+    if (result.ok) setReplacing(false);
+    return result;
+  };
+  const handleDetach = async (positionId: number) => {
+    const result = await detach(positionId);
+    if (result.ok) toast.success("Ticket removed from this account");
+    else toast.error(result.error);
+  };
+
+  const refreshButton = (
+    <RefreshTicketsButton
+      onRefresh={refresh}
+      isRefreshing={isRefreshing}
+      disabled={isLoading || isRefreshing || !online}
+    />
+  );
+  const connectionNotice = (error || !online) && (
+    <p className="text-xs text-dc-muted">
+      {online
+        ? "Couldn't refresh tickets. Showing your saved ones."
+        : "You're offline. Showing your saved tickets."}
+    </p>
+  );
+  const removedNotice = removedAttachments > 0 && (
+    <p className="text-xs text-dc-muted">
+      A ticket on this account is no longer yours in Pretix and was removed here.
+      {prompt !== null && " Pick or upload your ticket again."}
+    </p>
+  );
+  // Choosing needs the server; offline, the saved tickets and their QR codes
+  // stay reachable (the door does not wait) with a reminder to pick later.
+  const chooseLater = prompt === "choose" && !online && (
+    <p className="text-xs text-dc-muted">
+      Pick which ticket is yours when you&apos;re back online.
+    </p>
+  );
+
+  // Several tickets, none chosen: ask, and show no QR codes yet.
+  if (!isLoading && prompt === "choose" && online) {
+    return (
+      <div className="flex w-full flex-col gap-4 text-left">
+        <TicketSectionHeader title="My Event Ticket" action={refreshButton} />
+        {connectionNotice}
+        {removedNotice}
+        <ChooseTicketCard
+          choices={ticketChoices(tickets)}
+          accountEmail={user?.email ?? ""}
+          buyerOrders={buyerOrders}
+          onChoose={choose}
+          onAttach={attach}
+        />
+      </div>
+    );
+  }
 
   if (!isLoading && tickets.length > 0) {
     return (
-      <div className="w-full text-left">
+      <div className="flex w-full flex-col gap-6 text-left">
         {/* A failed revalidation must never hide cached tickets/QR codes:
             keep the sections and add a quiet notice instead (same rule as the
             home page's Tickets.tsx). Offline, say so plainly. */}
-        {(error || !online) && (
-          <p className="mb-2 text-xs text-dc-muted">
-            {online
-              ? "Couldn't refresh tickets. Showing your saved ones."
-              : "You're offline. Showing your saved tickets."}
-          </p>
-        )}
+        {connectionNotice}
+        {removedNotice}
+        {chooseLater}
+        {prompt === "none" && <AttachTicketCard variant="none" onAttach={attachAndClose} />}
         <TicketSections
           tickets={tickets}
           qrCodes={qrCodes}
+          primary={primary}
           onRefresh={refresh}
           isRefreshing={isRefreshing}
           refreshDisabled={isLoading || isRefreshing || !online}
+          onReplace={() => setReplacing(true)}
+          onDetach={handleDetach}
+          leadSlot={
+            replacing && (
+              <AttachTicketCard
+                variant="replace"
+                onAttach={attachAndClose}
+                onCancel={() => setReplacing(false)}
+              />
+            )
+          }
         />
+        {/* A buyer with several tickets still under their email sees this
+            whenever they land here, chosen ticket or not: the same block as
+            inside the select, in the same card frame. */}
+        {buyerOrders.length > 0 && (
+          <section className="flex flex-col gap-3 rounded-xl border border-dc-hairline bg-white p-4">
+            <BuyerOrdersHint orders={buyerOrders} />
+          </section>
+        )}
       </div>
     );
   }
@@ -46,16 +158,7 @@ export function MyTickets() {
   // an order that just flipped to paid only shows up after a reload.
   return (
     <div className="flex w-full flex-col gap-4 text-left">
-      <TicketSectionHeader
-        title="My Event Ticket"
-        action={
-          <RefreshTicketsButton
-            onRefresh={refresh}
-            isRefreshing={isRefreshing}
-            disabled={isLoading || isRefreshing || !online}
-          />
-        }
-      />
+      <TicketSectionHeader title="My Event Ticket" action={refreshButton} />
       {isLoading ? (
         <p className="text-sm text-dc-muted">Loading tickets…</p>
       ) : error ? (
@@ -63,30 +166,13 @@ export function MyTickets() {
           Couldn&apos;t load tickets: {error.message}
         </p>
       ) : (
-        <div className="relative overflow-hidden rounded-2xl p-6 text-white">
-          {/* Real banner art from devcon.org/tickets + gradient for legibility */}
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img
-            src="/tickets-hero.jpg"
-            alt=""
-            className="absolute inset-0 h-full w-full object-cover"
-          />
-          <div className="absolute inset-0 bg-gradient-to-r from-[#1b0a45]/90 via-[#1b0a45]/60 to-transparent" />
-          <div className="relative min-w-0">
-            <h3 className="text-lg font-bold">Welcome!</h3>
-            <p className="mt-1 max-w-xs text-sm text-white/80">
-              We couldn&apos;t find any tickets for your email yet.
-            </p>
-            <a
-              href="https://devcon.org/tickets"
-              target="_blank"
-              rel="noreferrer"
-              className="mt-4 inline-flex rounded-full bg-white px-5 py-2.5 text-sm font-semibold text-[#3D00BF] transition-colors hover:bg-white/90"
-            >
-              Get tickets
-            </a>
-          </div>
-        </div>
+        <>
+          {/* No ticket under this email: instead of an empty state, the way
+              forward (spec). */}
+          {removedNotice}
+          <AttachTicketCard variant="none" onAttach={attachAndClose} />
+          {purchaseLink}
+        </>
       )}
     </div>
   );

--- a/event-app/src/components/Tickets.tsx
+++ b/event-app/src/components/Tickets.tsx
@@ -9,6 +9,7 @@ import {
   TicketSections,
 } from "./ticket/TicketSections";
 import { useRetryOnReconnect } from "@/hooks/useRetryOnReconnect";
+import { useOnline } from "@/hooks/useOnline";
 
 /** Home-page tickets section: signed in it renders the shared My Devcon
  *  layout (TicketSections); signed out it becomes the key-art sign-in banner
@@ -19,10 +20,13 @@ export function Tickets() {
     markFailed: markBannerFailed,
   } = useRetryOnReconnect();
   const { user } = useUser();
-  const { tickets, qrCodes, isLoading, isRefreshing, error, refresh } =
+  const { tickets, primary, prompt, qrCodes, isLoading, isRefreshing, error, refresh } =
     useTickets();
+  const online = useOnline();
 
   const hasTickets = tickets.length > 0;
+  // Offline the choice cannot be made, so the saved tickets show as before.
+  const askToChoose = prompt === "choose" && online;
 
   return (
     <section className="w-full text-left">
@@ -30,7 +34,7 @@ export function Tickets() {
           the "Your tickets" header only fronts the states that render without
           them, and keeps refresh reachable for signed-in users so a just-paid
           order can be refetched without a reload. */}
-      {(isLoading || !user || !hasTickets) && (
+      {(isLoading || !user || !hasTickets || askToChoose) && (
         <div className="mb-4">
           <TicketSectionHeader
             title="Your tickets"
@@ -109,6 +113,21 @@ export function Tickets() {
         <p className="text-sm text-dc-error">
           Couldn&apos;t load tickets: {error.message}
         </p>
+      ) : askToChoose ? (
+        /* Several tickets under this email and none chosen yet: the ticket
+           tab asks which is theirs; no QR codes until then. */
+        <div className="flex flex-col gap-3 rounded-xl border border-dc-hairline bg-white p-4">
+          <h3 className="font-heading text-[16px] font-bold leading-6 text-dc-fg2">
+            Which ticket is yours?
+          </h3>
+          <p className="text-[14px] leading-5 text-dc-fg2">
+            Several tickets are under this email.{" "}
+            <Link href="/ticket" className="font-bold text-dc-purple hover:underline">
+              Pick yours
+            </Link>{" "}
+            to see its QR code.
+          </p>
+        </div>
       ) : !hasTickets ? (
         <div className="relative overflow-hidden rounded-xl p-6 text-white">
           {/* Real banner art from devcon.org/tickets + gradient for legibility */}
@@ -132,6 +151,13 @@ export function Tickets() {
             >
               Get tickets
             </a>
+            {/* Ticket bought by someone else: the attach flow lives on the tab. */}
+            <p className="mt-3 text-sm text-white/90">
+              Have your ticket?{" "}
+              <Link href="/ticket" className="font-bold underline underline-offset-2">
+                Attach it on My Devcon
+              </Link>
+            </p>
           </div>
         </div>
       ) : (
@@ -143,9 +169,15 @@ export function Tickets() {
               Couldn&apos;t refresh tickets. Showing your saved ones.
             </p>
           )}
+          {prompt === "choose" && !online && (
+            <p className="mb-2 text-xs text-dc-muted">
+              Pick which ticket is yours when you&apos;re back online.
+            </p>
+          )}
           <TicketSections
             tickets={tickets}
             qrCodes={qrCodes}
+            primary={primary}
             onRefresh={refresh}
             isRefreshing={isRefreshing}
             refreshDisabled={isLoading || isRefreshing}

--- a/event-app/src/components/ticket/AttachTicketCard.tsx
+++ b/event-app/src/components/ticket/AttachTicketCard.tsx
@@ -215,10 +215,10 @@ export function ChooseTicketCard({
 
   /**
    * Line 1, bold: the identifier, the one thing that differs between rows
-   * ("Order KXQFQ · Ticket #1", the order only when several are involved). Line 2: the
+   * ("Order ABCDE · Ticket #1", the order only when several are involved). Line 2: the
    * ticket type, a holder other than you, and the status note. Line 3: swag.
    */
-  // Non-breaking spaces keep "Order KXQFQ" and "Ticket #1" whole when the line wraps.
+  // Non-breaking spaces keep "Order ABCDE" and "Ticket #1" whole when the line wraps.
   const reference = (choice: TicketChoice) =>
     severalOrders
       ? `Order\u00a0${choice.orderCode} · Ticket\u00a0#${choice.ordinal}`

--- a/event-app/src/components/ticket/AttachTicketCard.tsx
+++ b/event-app/src/components/ticket/AttachTicketCard.tsx
@@ -1,0 +1,314 @@
+"use client";
+
+import { useRef, useState } from "react";
+import cn from "classnames";
+import { Loader2, Upload, Users } from "lucide-react";
+import { toast } from "sonner";
+import { PrimaryButton } from "@/components/Buttons";
+import { NeedsConnection } from "@/components/NeedsConnection";
+import { useOnline } from "@/hooks/useOnline";
+import { useUser } from "@/data/auth/useUser";
+import type { AttachResult } from "@/data/tickets/useTickets";
+import type { BuyerOrder, TicketChoice } from "@/data/tickets/primary";
+import { ACCEPTED_TICKET_FILES, isUnsupportedPhotoFormat } from "@/data/tickets/qrFromFile";
+import { BuyerOrdersHint } from "./BuyerOrdersHint";
+import { displayItemName } from "./ticketTheme";
+
+const NO_CODE =
+  "No ticket code found in this file. Try the ticket PDF, the wallet pass (.pkpass), or a screenshot that shows the QR code large and sharp.";
+const UNSUPPORTED_PHOTO =
+  "This photo format can't be read here. Take a screenshot of it, or use the ticket PDF or the wallet pass (.pkpass).";
+
+const CARD = "flex flex-col gap-3 rounded-xl border border-dc-hairline bg-white p-4";
+const TITLE = "text-[16px] font-bold leading-6 text-dc-fg2";
+const BODY = "text-[14px] leading-5 text-dc-fg2";
+const HINT = "text-[12px] leading-4 text-dc-muted";
+const TEXT_LINK =
+  "cursor-pointer font-bold text-dc-purple hover:underline disabled:cursor-default disabled:opacity-50";
+
+type Stage = "idle" | "decoding" | "verifying";
+
+/**
+ * The upload path shared by the prompts: a plain file input covers the photo
+ * library, files (the ticket PDF, the wallet pass) and, on iOS, the camera,
+ * with no permission prompt of our own. The QR is decoded on the device; only
+ * the decoded code goes to the server. Needs a connection for the Pretix check.
+ */
+function useQrUpload(onAttach: (code: string) => Promise<AttachResult>) {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [stage, setStage] = useState<Stage>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const handleFile = async (file: File | undefined) => {
+    if (!file || stage !== "idle") return;
+    setError(null);
+    setStage("decoding");
+    try {
+      const { decodeQrFromFile } = await import("@/data/tickets/qrFromFile");
+      const code = await decodeQrFromFile(file);
+      if (!code) {
+        // HEIC from an iPhone decodes in Safari but nowhere else; say so
+        // instead of blaming the picture.
+        setError(isUnsupportedPhotoFormat(file) ? UNSUPPORTED_PHOTO : NO_CODE);
+        return;
+      }
+      setStage("verifying");
+      const result = await onAttach(code);
+      if (result.ok) toast.success("Ticket added");
+      else setError(result.error);
+    } finally {
+      setStage("idle");
+      // Let the same file be picked again after a failure.
+      if (inputRef.current) inputRef.current.value = "";
+    }
+  };
+
+  const input = (
+    <input
+      ref={inputRef}
+      type="file"
+      accept={ACCEPTED_TICKET_FILES}
+      // display:none, not sr-only: the picker still opens from .click(), and
+      // "No file chosen" never reaches the page text.
+      className="hidden"
+      tabIndex={-1}
+      aria-hidden
+      onChange={(e) => void handleFile(e.target.files?.[0])}
+    />
+  );
+  const label =
+    stage === "decoding"
+      ? "Reading your ticket…"
+      : stage === "verifying"
+        ? "Checking your ticket…"
+        : null;
+
+  return { input, open: () => inputRef.current?.click(), busy: stage !== "idle", label, error, setError };
+}
+
+/** Always mounted so the card does not jump when a message appears. */
+function ErrorLine({ error }: { error: string | null }) {
+  return (
+    <p className="min-h-5 text-[14px] leading-5 text-dc-error" aria-live="polite">
+      {error ?? ""}
+    </p>
+  );
+}
+
+export type AttachVariant = "none" | "replace";
+
+const COPY: Record<AttachVariant, { title: string; body: string }> = {
+  none: {
+    title: "No ticket found for this email",
+    body: "Have your ticket? Upload it: the ticket PDF, the wallet pass (.pkpass), or a screenshot of its QR code.",
+  },
+  replace: {
+    title: "Not your ticket?",
+    body: "Upload yours, as the ticket PDF, the wallet pass (.pkpass), or a screenshot of its QR code. It will take this one's place here.",
+  },
+};
+
+/** Upload-only prompt: no ticket under this email, or replacing the one shown. */
+export function AttachTicketCard({
+  variant,
+  onAttach,
+  onCancel,
+}: {
+  variant: AttachVariant;
+  onAttach: (code: string) => Promise<AttachResult>;
+  onCancel?: () => void;
+}) {
+  const online = useOnline();
+  const { signOut, loading } = useUser();
+  const upload = useQrUpload(onAttach);
+
+  return (
+    <section className={CARD}>
+      <h2 className={TITLE}>{COPY[variant].title}</h2>
+      <p className={BODY}>{COPY[variant].body}</p>
+      <p className={HINT}>Any of the ticket email attachments works, or a screenshot of the QR code.</p>
+      {upload.input}
+      <PrimaryButton
+        type="button"
+        className="min-h-12 w-full"
+        onClick={upload.open}
+        disabled={upload.busy || !online}
+      >
+        <Upload className="size-4" />
+        {upload.label ?? "Upload your ticket"}
+      </PrimaryButton>
+      {!online && <NeedsConnection what="Attaching a ticket" />}
+      <ErrorLine error={upload.error} />
+      {variant === "none" && (
+        // The most common "no ticket" is simply the wrong sign-in address.
+        <p className={BODY}>
+          Signed in with a different email than the one on your ticket?{" "}
+          <button
+            type="button"
+            onClick={signOut}
+            disabled={loading !== false}
+            className={TEXT_LINK}
+          >
+            Sign out and use that one
+          </button>
+        </p>
+      )}
+      {onCancel && (
+        <div className="flex items-center justify-end text-[14px] leading-none">
+          <button type="button" onClick={onCancel} className="cursor-pointer text-dc-muted hover:underline">
+            Cancel
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+/**
+ * Several tickets under this email and none chosen: pick one. The email match
+ * already proves possession, so choosing needs no QR; the screenshot stays as
+ * the way out when the rows cannot be told apart (same type, same email, no
+ * names). No QR codes show until a choice is made.
+ */
+export function ChooseTicketCard({
+  choices,
+  accountEmail,
+  buyerOrders,
+  onChoose,
+  onAttach,
+}: {
+  choices: TicketChoice[];
+  /** The signed-in email: rows only name a holder when it differs from it. */
+  accountEmail: string;
+  /** Orders the account bought with several tickets still under its email (see BuyerOrdersHint). */
+  buyerOrders: BuyerOrder[];
+  onChoose: (positionId: number) => Promise<AttachResult>;
+  onAttach: (code: string) => Promise<AttachResult>;
+}) {
+  const online = useOnline();
+  const upload = useQrUpload(onAttach);
+  const [choosing, setChoosing] = useState<number | null>(null);
+  const busy = upload.busy || choosing !== null;
+
+  const account = accountEmail.toLowerCase();
+  const severalOrders = new Set(choices.map((choice) => choice.orderCode)).size > 1;
+
+  const choose = async (positionId: number) => {
+    setChoosing(positionId);
+    upload.setError(null);
+    try {
+      const result = await onChoose(positionId);
+      if (result.ok) {
+        toast.success("Set as your ticket", {
+          description: "Your interests, Q&A and swag follow it. The others stay in your Pretix email.",
+          // Two sentences to read; the default 4 s is gone before the second,
+          // and a close button lets a fast reader dismiss it early.
+          duration: 8_000,
+          closeButton: true,
+        });
+      }
+      else upload.setError(result.error);
+    } finally {
+      setChoosing(null);
+    }
+  };
+
+  /**
+   * Line 1, bold: the identifier, the one thing that differs between rows
+   * ("Order KXQFQ · Ticket #1", the order only when several are involved). Line 2: the
+   * ticket type, a holder other than you, and the status note. Line 3: swag.
+   */
+  // Non-breaking spaces keep "Order KXQFQ" and "Ticket #1" whole when the line wraps.
+  const reference = (choice: TicketChoice) =>
+    severalOrders
+      ? `Order\u00a0${choice.orderCode} · Ticket\u00a0#${choice.ordinal}`
+      : `Ticket\u00a0#${choice.ordinal}`;
+  const swag = (choice: TicketChoice) => choice.addons.map(displayItemName).join(" · ");
+
+  return (
+    <section className={CARD}>
+      <h2 className={TITLE}>Which ticket is yours?</h2>
+      <p className={BODY}>
+        {choices.length} tickets are under this email. Pick yours to see its QR code; the others
+        stay in your Pretix email. Your interests, Q&amp;A and swag follow this ticket.
+      </p>
+      <ul className="flex flex-col gap-2">
+        {choices.map((choice) => (
+          <li
+            key={choice.secret}
+            // Phone: text on top, button below it right-aligned, so neither
+            // squeezes the other. Desktop: one row.
+            className="flex flex-col gap-2 rounded-lg border border-dc-hairline bg-dc-panel px-3 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-3 lg:py-2"
+          >
+            {/* Wrap, never truncate: on a phone the details line is the only
+                way to tell two same-type tickets apart. */}
+            <div className="min-w-0 [overflow-wrap:anywhere]">
+              <p className="text-[14px] font-bold leading-5 text-dc-fg2">{reference(choice)}</p>
+              <p className="text-[12px] leading-4 text-dc-fg2">
+                {displayItemName(choice.itemName)}
+                {choice.test && <span className="text-dc-muted"> (test ticket)</span>}
+                {choice.holder.toLowerCase() !== account && <> · {choice.holder}</>}
+                {choice.sharedWith ? (
+                  <span className="text-dc-muted">
+                    {" · "}
+                    <span className="whitespace-nowrap">
+                      <Users className="inline size-3 -translate-y-px" aria-hidden />
+                      {" "}attached
+                    </span>{" "}
+                    by someone else
+                  </span>
+                ) : null}
+              </p>
+              {swag(choice) && (
+                <p className="text-[12px] leading-4 text-dc-muted">{swag(choice)}</p>
+              )}
+            </div>
+            {choice.positionId !== undefined ? (
+              <button
+                type="button"
+                onClick={() => void choose(choice.positionId as number)}
+                disabled={busy || !online}
+                className={cn(
+                  "flex h-8 shrink-0 cursor-pointer items-center gap-1.5 self-end rounded-full border border-dc-hairline bg-white px-3 text-[12px] font-semibold leading-none text-dc-fg2 transition-colors duration-150 ease-out hover:bg-dc-purple-wash disabled:cursor-default disabled:opacity-50 lg:self-auto"
+                )}
+              >
+                {/* No resting icon: a check made every row look already chosen. */}
+                {choosing === choice.positionId && (
+                  <Loader2 className="size-4 animate-spin text-dc-purple" />
+                )}
+                {choosing === choice.positionId ? "Adding…" : "This one is mine"}
+              </button>
+            ) : (
+              // No position id: a payload cached by an older build, which a
+              // refresh fixes (fixture tickets carry synthetic ids).
+              <span className="shrink-0 self-end text-[12px] leading-none text-dc-muted lg:self-auto">Refresh to choose</span>
+            )}
+          </li>
+        ))}
+      </ul>
+      {upload.input}
+      {/* The way out when rows look alike: same stacked-then-row shape as the
+          rows above, with a pill instead of a text link buried in a sentence. */}
+      <div className="flex flex-col gap-2 rounded-lg border border-dashed border-dc-hairline px-3 py-3 lg:flex-row lg:items-center lg:justify-between lg:gap-3 lg:py-2">
+        <div className="min-w-0">
+          <p className="text-[14px] font-bold leading-5 text-dc-fg2">Can&apos;t tell them apart?</p>
+          <p className="text-[12px] leading-4 text-dc-muted">
+            Upload your ticket: the PDF, the wallet pass (.pkpass), or a screenshot of its QR code.
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={upload.open}
+          disabled={busy || !online}
+          className="flex h-8 shrink-0 cursor-pointer items-center gap-1.5 self-end rounded-full border border-dc-hairline bg-white px-3 text-[12px] font-semibold leading-none text-dc-fg2 transition-colors duration-150 ease-out hover:bg-dc-purple-wash disabled:cursor-default disabled:opacity-50 lg:self-auto"
+        >
+          <Upload className="size-4 text-dc-purple" />
+          {upload.label ?? "Upload your ticket"}
+        </button>
+      </div>
+      <BuyerOrdersHint orders={buyerOrders} />
+      {!online && <NeedsConnection what="Choosing a ticket" />}
+      <ErrorLine error={upload.error} />
+    </section>
+  );
+}

--- a/event-app/src/components/ticket/BuyerOrdersHint.tsx
+++ b/event-app/src/components/ticket/BuyerOrdersHint.tsx
@@ -7,7 +7,7 @@ import type { BuyerOrder } from "@/data/tickets/primary";
  * Nudge for a buyer whose order still holds several tickets under their own
  * email: set each holder's email on their ticket in Pretix so the holders sign
  * in with it, find their ticket loaded, and never need to choose or upload.
- * One chip per ticket, labelled like the select rows ("Order KXQFQ · Ticket
+ * One chip per ticket, labelled like the select rows ("Order ABCDE · Ticket
  * #1"); Pretix has no per-ticket page on this instance, so each opens the
  * order's "change details" form (<order url>/modify), which covers every
  * ticket on it. Renders nothing when there is no such order.

--- a/event-app/src/components/ticket/BuyerOrdersHint.tsx
+++ b/event-app/src/components/ticket/BuyerOrdersHint.tsx
@@ -1,0 +1,43 @@
+"use client";
+
+import { ExternalLink } from "lucide-react";
+import type { BuyerOrder } from "@/data/tickets/primary";
+
+/**
+ * Nudge for a buyer whose order still holds several tickets under their own
+ * email: set each holder's email on their ticket in Pretix so the holders sign
+ * in with it, find their ticket loaded, and never need to choose or upload.
+ * One chip per ticket, labelled like the select rows ("Order KXQFQ · Ticket
+ * #1"); Pretix has no per-ticket page on this instance, so each opens the
+ * order page, where every ticket has its own "change details". Renders
+ * nothing when there is no such order.
+ */
+export function BuyerOrdersHint({ orders }: { orders: BuyerOrder[] }) {
+  if (orders.length === 0) return null;
+  const severalOrders = orders.length > 1;
+  return (
+    <div className="flex flex-col gap-2 text-[12px] leading-4 text-dc-muted">
+      <p>
+        <span className="font-bold text-dc-fg2">Bought tickets for others? </span>
+        Set each holder&apos;s email on their ticket in Pretix, so they can sign in with it and find
+        their ticket already loaded.
+      </p>
+      <div className="flex flex-wrap gap-2">
+        {orders.flatMap((order) =>
+          order.tickets.map((ticket) => (
+            <a
+              key={ticket.secret}
+              href={order.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-7 items-center gap-1 whitespace-nowrap rounded-full border border-dc-hairline bg-white px-2.5 text-[12px] font-semibold leading-none text-dc-purple transition-colors duration-150 ease-out hover:bg-dc-purple-wash"
+            >
+              {severalOrders ? `Order ${order.orderCode} · ` : ""}Ticket&nbsp;#{ticket.ordinal}
+              <ExternalLink className="size-3" />
+            </a>
+          ))
+        )}
+      </div>
+    </div>
+  );
+}

--- a/event-app/src/components/ticket/BuyerOrdersHint.tsx
+++ b/event-app/src/components/ticket/BuyerOrdersHint.tsx
@@ -9,9 +9,12 @@ import type { BuyerOrder } from "@/data/tickets/primary";
  * in with it, find their ticket loaded, and never need to choose or upload.
  * One chip per ticket, labelled like the select rows ("Order KXQFQ · Ticket
  * #1"); Pretix has no per-ticket page on this instance, so each opens the
- * order page, where every ticket has its own "change details". Renders
- * nothing when there is no such order.
+ * order's "change details" form (<order url>/modify), which covers every
+ * ticket on it. Renders nothing when there is no such order.
  */
+/** The Pretix order's attendee-details form, straight from the chip. */
+const modifyUrl = (orderUrl: string) => `${orderUrl.replace(/\/?$/, "/")}modify`;
+
 export function BuyerOrdersHint({ orders }: { orders: BuyerOrder[] }) {
   if (orders.length === 0) return null;
   const severalOrders = orders.length > 1;
@@ -27,7 +30,7 @@ export function BuyerOrdersHint({ orders }: { orders: BuyerOrder[] }) {
           order.tickets.map((ticket) => (
             <a
               key={ticket.secret}
-              href={order.url}
+              href={modifyUrl(order.url)}
               target="_blank"
               rel="noopener noreferrer"
               className="inline-flex h-7 items-center gap-1 whitespace-nowrap rounded-full border border-dc-hairline bg-white px-2.5 text-[12px] font-semibold leading-none text-dc-purple transition-colors duration-150 ease-out hover:bg-dc-purple-wash"

--- a/event-app/src/components/ticket/EventTicketCard.tsx
+++ b/event-app/src/components/ticket/EventTicketCard.tsx
@@ -18,13 +18,21 @@ import {
  * tear line with punched notches (`.ticket-notch-*` masks in globals.css);
  * the shadow is a drop-shadow on the wrapper so it follows the cutouts.
  */
+/** Human identifier printed under the QR: the order and the ticket's number in it (see ticketOrdinals). */
+export interface TicketReference {
+  orderCode: string;
+  ordinal: number;
+}
+
 export function EventTicketCard({
   ticket,
   qr,
+  reference,
   onQrClick,
 }: {
   ticket: Ticket;
   qr?: string;
+  reference?: TicketReference;
   onQrClick: (target: QrModalTarget) => void;
 }) {
   const { attempt: logoAttempt, markFailed: markLogoFailed } =
@@ -54,6 +62,7 @@ export function EventTicketCard({
                 title: modalTitle,
                 style,
                 checkedIn: ticket.hasCheckedIn,
+                reference,
               })
           : undefined
       }
@@ -93,6 +102,13 @@ export function EventTicketCard({
             >
               {holder}
             </p>
+            {reference && (
+              // Third line of the identity block (what, who, which): the same
+              // identifier the select rows and the Pretix order page use.
+              <p className="text-[11px] font-semibold leading-none text-dc-muted">
+                Order {reference.orderCode} · Ticket #{reference.ordinal}
+              </p>
+            )}
           </div>
         </div>
         <p className="mt-auto text-[10px] font-bold leading-none text-dc-muted">

--- a/event-app/src/components/ticket/QrModals.tsx
+++ b/event-app/src/components/ticket/QrModals.tsx
@@ -4,6 +4,7 @@ import { useEffect } from "react";
 import { AnimatePresence, motion } from "framer-motion";
 import { ArrowRight, Check } from "lucide-react";
 import type { TicketStyle } from "@/data/tickets/types";
+import type { TicketReference } from "./EventTicketCard";
 import { CloseButton } from "@/components/Buttons";
 import { TICKET_THEMES } from "./ticketTheme";
 
@@ -17,8 +18,16 @@ export type QrModalTarget =
       style: TicketStyle;
       /** Pretix has seen this ticket scanned at venue check-in. */
       checkedIn?: boolean;
+      /** Order code and the ticket's number in it, printed under the QR. */
+      reference?: TicketReference;
     }
-  | { kind: "swag"; qr: string; title: string };
+  | {
+      kind: "swag";
+      qr: string;
+      title: string;
+      /** Pretix has a check-in on the swag position: already handed over. */
+      collected?: boolean;
+    };
 
 const MODAL_BG = "linear-gradient(to top, #fbfafc 19.982%, #fff5fa 100%)";
 
@@ -86,6 +95,12 @@ export function QrModal({
               </div>
             </div>
 
+            {target.kind === "ticket" && target.reference && (
+              <p className="mt-2 text-[12px] font-semibold leading-4 text-dc-muted">
+                Order {target.reference.orderCode} · Ticket #{target.reference.ordinal}
+              </p>
+            )}
+
             <div className="flex w-full flex-col items-center gap-4 px-4 py-6 text-center">
               <div className="flex w-full flex-col gap-2">
                 <p className="text-[16px] font-bold leading-6 text-dc-fg2">
@@ -112,13 +127,23 @@ export function QrModal({
                       </span>
                     )}
                   </>
+                ) : target.collected ? (
+                  <>
+                    <p className="text-[14px] leading-5 text-dc-fg2">
+                      Already collected at the Swag Station
+                    </p>
+                    <span className="mt-1 inline-flex items-center gap-1 self-center rounded-full bg-dc-green-soft px-3 py-1 text-[12px] font-semibold leading-4 text-dc-fg2">
+                      <Check className="size-3.5" />
+                      Collected
+                    </span>
+                  </>
                 ) : (
                   <p className="text-[14px] leading-5 text-dc-fg2">
                     Present this QR at the Swag Station to claim
                   </p>
                 )}
               </div>
-              {target.kind === "swag" && (
+              {target.kind === "swag" && !target.collected && (
                 // Figma annotation: "Will link to Swag Station location on
                 // in-app map (future iteration)" — closes the modal until the
                 // station has a map POI. Sized per the design's Button-Small

--- a/event-app/src/components/ticket/SwagCard.tsx
+++ b/event-app/src/components/ticket/SwagCard.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import cn from "classnames";
-import { Gift, QrCode } from "lucide-react";
+import { Check, Gift, QrCode } from "lucide-react";
 import { useRetryOnReconnect } from "@/hooks/useRetryOnReconnect";
 import type { QrModalTarget } from "./QrModals";
 import { displayItemName } from "./ticketTheme";
@@ -21,12 +21,15 @@ export function SwagCard({
   title,
   imageUrl,
   qr,
+  collected = false,
   onQrClick,
   shelfOnDesktop = false,
 }: {
   title: string;
   imageUrl?: string;
   qr?: string;
+  /** Handed over at the swag station (Pretix check-in on the position). */
+  collected?: boolean;
   onQrClick: (target: QrModalTarget) => void;
   shelfOnDesktop?: boolean;
 }) {
@@ -40,7 +43,7 @@ export function SwagCard({
 
   return (
     <button
-      onClick={qr ? () => onQrClick({ kind: "swag", qr, title: name }) : undefined}
+      onClick={qr ? () => onQrClick({ kind: "swag", qr, title: name, collected }) : undefined}
       disabled={!qr}
       className={cn(
         // outline (not border) so the stroke sits just OUTSIDE the card
@@ -82,6 +85,13 @@ export function SwagCard({
             <Gift className="size-10 text-dc-purple-soft" aria-hidden="true" />
           </div>
         )}
+        {collected && (
+          // Same pill as the ticket's "Checked in" (sonner success palette).
+          <span className="absolute left-3 top-3 inline-flex items-center gap-1 rounded-full bg-dc-green-soft px-3 py-1 text-[12px] font-semibold leading-4 text-dc-fg2 shadow-sm">
+            <Check className="size-3.5" />
+            Collected
+          </span>
+        )}
       </div>
       <div
         className="flex w-full items-center gap-6 px-4 py-5"
@@ -92,7 +102,7 @@ export function SwagCard({
             {name}
           </p>
           <p className="text-[12px] font-medium leading-none text-[#9256d2]">
-            Swag
+            {collected ? "Swag · Collected" : "Swag"}
           </p>
         </div>
         <span className="flex size-8 shrink-0 items-center justify-center">

--- a/event-app/src/components/ticket/TicketSections.tsx
+++ b/event-app/src/components/ticket/TicketSections.tsx
@@ -94,7 +94,7 @@ export function TicketSections({
 }) {
   const [modal, setModal] = useState<QrModalTarget | null>(null);
 
-  // "Order KXQFQ · Ticket #1" under each QR: the identifier shared with the
+  // "Order ABCDE · Ticket #1" under each QR: the identifier shared with the
   // select rows and the Pretix order page.
   const ordinals = ticketOrdinals(tickets);
   const orderCodeBySecret = new Map<string, string>();

--- a/event-app/src/components/ticket/TicketSections.tsx
+++ b/event-app/src/components/ticket/TicketSections.tsx
@@ -4,6 +4,7 @@ import { useState, type ReactNode } from "react";
 import cn from "classnames";
 import { RefreshCw } from "lucide-react";
 import type { Order, Ticket } from "@/data/tickets/types";
+import { ticketOrdinals } from "@/data/tickets/primary";
 import { EventTicketCard } from "./EventTicketCard";
 import { EnsPerkCard } from "./EnsPerkCard";
 import { SwagCard } from "./SwagCard";
@@ -72,18 +73,50 @@ export function TicketSections({
   onRefresh,
   isRefreshing = false,
   refreshDisabled = false,
+  primary = null,
+  onReplace,
+  onDetach,
+  leadSlot,
 }: {
   tickets: Order[];
   qrCodes: Record<string, string>;
   onRefresh?: () => void;
   isRefreshing?: boolean;
   refreshDisabled?: boolean;
+  /** "My ticket" (data/tickets/primary.ts): the only ticket shown; the rest stay in the Pretix email. */
+  primary?: Ticket | null;
+  /** Ticket tab only: "Not your ticket? Attach yours" on an email-matched ticket, opens the replace card. */
+  onReplace?: () => void;
+  /** Ticket tab only: "Wrong ticket?" on an attached ticket (detach). */
+  onDetach?: (positionId: number) => void;
+  /** Ticket tab only: rendered right under the shown ticket (the replace card), where the link was tapped. */
+  leadSlot?: ReactNode;
 }) {
   const [modal, setModal] = useState<QrModalTarget | null>(null);
 
+  // "Order KXQFQ · Ticket #1" under each QR: the identifier shared with the
+  // select rows and the Pretix order page.
+  const ordinals = ticketOrdinals(tickets);
+  const orderCodeBySecret = new Map<string, string>();
+  for (const order of tickets) for (const t of order.tickets) orderCodeBySecret.set(t.secret, order.orderCode);
+  const referenceOf = (ticket: Ticket) => {
+    const orderCode = orderCodeBySecret.get(ticket.secret);
+    const ordinal = ordinals.get(ticket.secret);
+    return orderCode && ordinal ? { orderCode, ordinal } : undefined;
+  };
+
   const admissionTickets: Ticket[] = [];
-  const swagItems: Array<{ secret: string; title: string; imageUrl?: string }> =
-    [];
+  const swagItems: Array<{
+    secret: string;
+    title: string;
+    imageUrl?: string;
+    /** The admission ticket this swag goes with (itself for standalone merchandise). */
+    ownerSecret: string;
+    standalone: boolean;
+    orderCode: string;
+    /** Scanned at the swag station (a Pretix check-in on the position). */
+    collected: boolean;
+  }> = [];
   for (const order of tickets) {
     for (const ticket of order.tickets) {
       // `admission === false` is a Pretix item explicitly marked as
@@ -94,6 +127,10 @@ export function TicketSections({
           secret: ticket.secret,
           title: ticket.itemName,
           imageUrl: ticket.imageUrl,
+          ownerSecret: ticket.secret,
+          standalone: true,
+          orderCode: order.orderCode,
+          collected: ticket.hasCheckedIn === true,
         });
       } else {
         admissionTickets.push(ticket);
@@ -103,15 +140,72 @@ export function TicketSections({
           secret: addon.secret,
           title: addon.itemName,
           imageUrl: addon.imageUrl,
+          ownerSecret: ticket.secret,
+          standalone: false,
+          orderCode: order.orderCode,
+          collected: addon.collected === true,
         });
       }
     }
   }
 
+  // With a primary ticket only it is shown (decided 2026-09-09: the buyer's
+  // other tickets were forwarded to their holders and stay in the Pretix
+  // email). Swag and the perk follow the ticket shown: its add-ons, plus
+  // merchandise sold as its own position on the same order. Without a
+  // primary, today's layout: every ticket, every swag item.
+  const lead = primary
+    ? (admissionTickets.find((t) => t.secret === primary.secret) ?? null)
+    : null;
+  const shownTickets = lead ? [lead] : admissionTickets;
+  const leadOrderCode = lead
+    ? tickets.find((order) => order.tickets.some((t) => t.secret === lead.secret))?.orderCode
+    : undefined;
+  const shownSwag = lead
+    ? swagItems.filter(
+        (item) =>
+          item.ownerSecret === lead.secret ||
+          (item.standalone && item.orderCode === leadOrderCode)
+      )
+    : swagItems;
+  const leadPositionId = lead?.positionId;
+
   // With several tickets, both tickets and swag become full-width horizontal
   // carousels stacked vertically; with one, the ticket sits beside the swag
   // shelf in the Figma two-column layout.
-  const multiTicket = admissionTickets.length > 1;
+  const multiTicket = shownTickets.length > 1;
+
+  // Under the shown card (ticket tab only), one way out. An attached ticket
+  // can be detached: with two or more email-matched tickets left the select
+  // comes back ("Choose another"), otherwise the upload does or the one
+  // remaining ticket takes over ("Remove it"). An email-matched ticket can be
+  // replaced by uploading the right ticket's QR, which then takes its place
+  // (attached wins in derivePrimary).
+  const emailMatched = admissionTickets.filter((t) => !t.attached).length;
+  const leadFooter =
+    lead &&
+    (lead.attached
+      ? leadPositionId !== undefined &&
+        onDetach && (
+          <button
+            type="button"
+            onClick={() => leadPositionId !== undefined && onDetach(leadPositionId)}
+            className="self-start text-[14px] leading-5 text-dc-purple hover:underline"
+          >
+            {emailMatched >= 2
+              ? "Wrong ticket? Choose another"
+              : "Wrong ticket? Remove it from this account"}
+          </button>
+        )
+      : onReplace && (
+          <button
+            type="button"
+            onClick={onReplace}
+            className="self-start text-[14px] leading-5 text-dc-purple hover:underline"
+          >
+            Not your ticket? Attach yours
+          </button>
+        ));
 
   const ticketHeader = (
     <TicketSectionHeader
@@ -141,7 +235,7 @@ export function TicketSections({
     <div aria-hidden className="hidden w-9 shrink-0 lg:block" />
   );
 
-  const swagSection = swagItems.length > 0 && (
+  const swagSection = shownSwag.length > 0 && (
     <section
       className={cn(
         "flex w-full flex-col gap-4",
@@ -160,12 +254,13 @@ export function TicketSections({
         )}
       >
         <div className={cn(scrollerBase, "lg:absolute lg:-inset-3 lg:p-3")}>
-          {swagItems.map((item) => (
+          {shownSwag.map((item) => (
             <SwagCard
               key={item.secret}
               title={item.title}
               imageUrl={item.imageUrl}
               qr={qrCodes[item.secret]}
+              collected={item.collected}
               onQrClick={setModal}
               shelfOnDesktop
             />
@@ -188,7 +283,7 @@ export function TicketSections({
                 shadow beyond the 1.03 scale. Each wrapper is a flex box so
                 the stretched cards equalize to the tallest. */}
             <div className={cn(scrollerBase, "lg:-m-5 lg:p-5")}>
-              {admissionTickets.map((ticket) => (
+              {shownTickets.map((ticket) => (
                 <div
                   key={ticket.secret}
                   className="w-full lg:flex lg:w-[400px] lg:shrink-0"
@@ -196,6 +291,7 @@ export function TicketSections({
                   <EventTicketCard
                     ticket={ticket}
                     qr={qrCodes[ticket.secret]}
+                    reference={referenceOf(ticket)}
                     onQrClick={setModal}
                   />
                 </div>
@@ -211,29 +307,40 @@ export function TicketSections({
         <div className="flex flex-col gap-6 lg:flex-row lg:gap-8">
           <section className="flex w-full flex-col gap-4 lg:w-[400px] lg:shrink-0">
             {ticketHeader}
-            {admissionTickets.map((ticket) => (
+            {shownTickets.map((ticket) => (
               <EventTicketCard
                 key={ticket.secret}
                 ticket={ticket}
                 qr={qrCodes[ticket.secret]}
+                reference={referenceOf(ticket)}
                 onQrClick={setModal}
               />
             ))}
+            {lead?.sharedWith ? (
+              // Two accounts on one ticket is allowed; the door decides, so
+              // say it here rather than surprise anyone there.
+              <p className="text-[12px] leading-4 text-dc-muted">
+                Also attached to another account. Only one person can enter the venue with this ticket.
+              </p>
+            ) : null}
+            {leadFooter}
+            {leadSlot}
           </section>
           {swagSection}
         </div>
       )}
 
-      {/* One ENS perk per event ticket (see TicketProofButton). */}
-      {admissionTickets.length > 0 && (
+      {/* One ENS perk per ticket shown (see TicketProofButton): with a primary
+          that is one card, never the buyer's colleagues' perks. */}
+      {shownTickets.length > 0 && (
         <section className="flex w-full flex-col gap-4">
           <TicketSectionHeader title="My Perks" />
           <div className="flex flex-col gap-4 lg:flex-row lg:flex-wrap">
-            {admissionTickets.map((ticket) => (
+            {shownTickets.map((ticket) => (
               <EnsPerkCard
                 key={ticket.secret}
                 ticket={ticket}
-                showTicketLabel={admissionTickets.length > 1}
+                showTicketLabel={shownTickets.length > 1}
               />
             ))}
           </div>

--- a/event-app/src/data/cache/cache-db.ts
+++ b/event-app/src/data/cache/cache-db.ts
@@ -96,7 +96,14 @@ export interface SeenAnnouncement {
 export interface InterestedSession {
   eventId: string;
   sessionId: string;
+  /** When the star was first set on this device. */
   addedAt: number;
+  /** False is a tombstone: unstarred, kept so the removal syncs and wins by time. */
+  interested: boolean;
+  /** Device time of the last change (ms); last write wins across devices. */
+  updatedAt: number;
+  /** 1 until the account has this change (0 once pushed, or when it came from the account). */
+  pending: number;
 }
 
 /**
@@ -108,6 +115,16 @@ export interface InterestedSpeaker {
   eventId: string;
   speakerId: string;
   addedAt: number;
+  interested: boolean;
+  updatedAt: number;
+  pending: number;
+}
+
+/** Per account and event: the server cursor of the last completed interests sync. */
+export interface InterestSyncMeta {
+  /** `<userId>|<eventId>` */
+  key: string;
+  lastSyncAt: number;
 }
 
 class CacheDB extends Dexie {
@@ -117,6 +134,7 @@ class CacheDB extends Dexie {
   seenAnnouncements!: Table<SeenAnnouncement, string>;
   interested!: Table<InterestedSession, [string, string]>;
   interestedSpeakers!: Table<InterestedSpeaker, [string, string]>;
+  interestSync!: Table<InterestSyncMeta, string>;
   // v7: normalised event catalogue (EventStore). One row per session /
   // speaker / room per event, plus one meta row (version, sync times).
   eventSessions!: Table<SessionRow, [string, string]>;
@@ -167,6 +185,24 @@ class CacheDB extends Dexie {
           .filter((row: { key: string }) => LEGACY_CATALOGUE_KEY.test(row.key))
           .delete()
       );
+    // v8: stars sync to the account (data/interested/sync.ts). Rows gain a
+    // tombstone flag, a change time and a pending flag; existing stars become
+    // pending so a first sign-in pushes them. `interestSync` holds the cursor.
+    this.version(8)
+      .stores({
+        interested: "&[eventId+sessionId], eventId, pending",
+        interestedSpeakers: "&[eventId+speakerId], eventId, pending",
+        interestSync: "&key",
+      })
+      .upgrade(async (tx) => {
+        const stamp = (row: { addedAt?: number; interested?: boolean; updatedAt?: number; pending?: number }) => {
+          row.interested = true;
+          row.updatedAt = row.addedAt ?? Date.now();
+          row.pending = 1;
+        };
+        await tx.table("interested").toCollection().modify(stamp);
+        await tx.table("interestedSpeakers").toCollection().modify(stamp);
+      });
   }
 }
 

--- a/event-app/src/data/interested/InterestSync.tsx
+++ b/event-app/src/data/interested/InterestSync.tsx
@@ -1,0 +1,46 @@
+"use client";
+
+import { useEffect } from "react";
+import { useSWRConfig } from "swr";
+import { useUser } from "@/data/auth/useUser";
+import { useOnline } from "@/hooks/useOnline";
+import { getActiveDataset } from "@/data/dataset";
+import { requestInterestSync, setSyncContext } from "./sync";
+
+/**
+ * Mounts the interests sync triggers (see sync.ts): the account context while
+ * signed in, then a sync on sign-in, when the connection returns and when the
+ * tab becomes visible again. Renders nothing; mount once inside UserProvider.
+ * Uses the SWR config's `mutate`, since the app runs a custom cache provider
+ * that the global `mutate` from "swr" does not see.
+ */
+export function InterestSync() {
+  const { user } = useUser();
+  const userId = user?.id;
+  const { mutate } = useSWRConfig();
+  const online = useOnline();
+  const eventId = getActiveDataset().eventId;
+
+  useEffect(() => {
+    if (!userId) {
+      setSyncContext(null);
+      return;
+    }
+    setSyncContext({ userId, eventId, mutate: (key) => mutate(key) });
+    requestInterestSync(0);
+    const onVisible = () => {
+      if (document.visibilityState === "visible") requestInterestSync(0);
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      document.removeEventListener("visibilitychange", onVisible);
+      setSyncContext(null);
+    };
+  }, [userId, eventId, mutate]);
+
+  useEffect(() => {
+    if (online && userId) requestInterestSync(0);
+  }, [online, userId]);
+
+  return null;
+}

--- a/event-app/src/data/interested/merge.ts
+++ b/event-app/src/data/interested/merge.ts
@@ -1,0 +1,32 @@
+/**
+ * Last-write-wins merge of a star between the device and the account (pure).
+ * A row is `interested` or a tombstone, stamped with the device time of the
+ * change; `pending` is 1 until the account has seen it.
+ */
+export interface LocalInterest {
+  interested: boolean;
+  updatedAt: number;
+  pending: number;
+}
+
+/**
+ * Apply a change from the account to the local row: a newer remote change
+ * wins; a tie or an older one keeps the local row (returns null).
+ */
+export function mergeRemote(
+  local: LocalInterest | undefined,
+  remote: { interested: boolean; updatedAt: number }
+): LocalInterest | null {
+  if (local && local.updatedAt >= remote.updatedAt) return null;
+  return { interested: remote.interested, updatedAt: remote.updatedAt, pending: 0 };
+}
+
+/**
+ * After a push: the row is settled (no longer pending) only if it did not
+ * change again while the request was in flight; otherwise the newer change
+ * stays pending for the next sync (returns null).
+ */
+export function settlePending(local: LocalInterest, pushedUpdatedAt: number): LocalInterest | null {
+  if (local.updatedAt !== pushedUpdatedAt) return null;
+  return { ...local, pending: 0 };
+}

--- a/event-app/src/data/interested/sync.ts
+++ b/event-app/src/data/interested/sync.ts
@@ -1,0 +1,166 @@
+"use client";
+
+import { cacheDB } from "../cache/cache-db";
+import { supabase } from "../auth/supabase";
+import { isOnlineNow } from "@/hooks/useOnline";
+import { mergeRemote, settlePending } from "./merge";
+import type { InterestChange, SyncResponse } from "./syncProtocol";
+
+/**
+ * Keeps the device's stars and the account's in step. Dexie stays the source
+ * of truth and the app never waits on this: a sync pushes the
+ * rows still marked pending, pulls what other devices wrote since the last
+ * cursor, merges last-write-wins per item and refreshes the two SWR keys.
+ * Failures leave rows pending for the next trigger (sign-in, reconnect, tab
+ * focus, or 1.5 s after a toggle).
+ */
+
+type Mutate = (key: [string, string]) => Promise<unknown>;
+
+interface SyncContext {
+  userId: string;
+  eventId: string;
+  mutate: Mutate;
+}
+
+const DEBOUNCE_MS = 1_500;
+
+let context: SyncContext | null = null;
+let timer: ReturnType<typeof setTimeout> | null = null;
+let inFlight: Promise<void> | null = null;
+/** A trigger arrived while a sync was running: run once more afterwards. */
+let again = false;
+
+/** Set by InterestSync while signed in; null signed out (stars stay local). */
+export function setSyncContext(next: SyncContext | null): void {
+  context = next;
+}
+
+export function requestInterestSync(delayMs = DEBOUNCE_MS): void {
+  if (!context) return;
+  if (timer) clearTimeout(timer);
+  timer = setTimeout(() => {
+    timer = null;
+    void runSync();
+  }, delayMs);
+}
+
+export function runSync(): Promise<void> {
+  if (inFlight) {
+    again = true;
+    return inFlight;
+  }
+  inFlight = doSync()
+    .catch((err) => {
+      console.warn("[interests] sync failed, will retry on the next trigger:", err);
+    })
+    .finally(() => {
+      inFlight = null;
+      if (again) {
+        again = false;
+        void runSync();
+      }
+    });
+  return inFlight;
+}
+
+async function doSync(): Promise<void> {
+  if (!cacheDB || !context || !isOnlineNow() || !supabase) return;
+  const { userId, eventId, mutate } = context;
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  const token = session?.access_token;
+  if (!token) return;
+
+  const metaKey = `${userId}|${eventId}`;
+  const meta = await cacheDB.interestSync.get(metaKey);
+  const pendingSessions = await cacheDB.interested
+    .where("pending")
+    .equals(1)
+    .and((row) => row.eventId === eventId)
+    .toArray();
+  const pendingSpeakers = await cacheDB.interestedSpeakers
+    .where("pending")
+    .equals(1)
+    .and((row) => row.eventId === eventId)
+    .toArray();
+  const changes: InterestChange[] = [
+    ...pendingSessions.map((row) => ({
+      kind: "session" as const,
+      id: row.sessionId,
+      interested: row.interested !== false,
+      updatedAt: row.updatedAt,
+    })),
+    ...pendingSpeakers.map((row) => ({
+      kind: "speaker" as const,
+      id: row.speakerId,
+      interested: row.interested !== false,
+      updatedAt: row.updatedAt,
+    })),
+  ];
+
+  const res = await fetch("/api/interests/sync", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ event: eventId, since: meta?.lastSyncAt ?? null, changes }),
+  });
+  const json = (await res.json()) as { success: boolean; data?: SyncResponse; error?: string };
+  if (!json.success || !json.data) throw new Error(json.error || `HTTP ${res.status}`);
+  const { changes: remote, now } = json.data;
+
+  // The context may have changed while the request was out (sign-out, other
+  // account): never write another account's answer into this device.
+  if (!context || context.userId !== userId || context.eventId !== eventId) return;
+
+  await cacheDB.transaction(
+    "rw",
+    [cacheDB.interested, cacheDB.interestedSpeakers, cacheDB.interestSync],
+    async () => {
+      for (const change of remote) {
+        if (change.kind === "session") {
+          const key: [string, string] = [eventId, change.id];
+          const local = await cacheDB.interested.get(key);
+          const merged = mergeRemote(local, change);
+          if (merged) {
+            await cacheDB.interested.put({
+              eventId,
+              sessionId: change.id,
+              addedAt: local?.addedAt ?? change.updatedAt,
+              ...merged,
+            });
+          }
+        } else {
+          const key: [string, string] = [eventId, change.id];
+          const local = await cacheDB.interestedSpeakers.get(key);
+          const merged = mergeRemote(local, change);
+          if (merged) {
+            await cacheDB.interestedSpeakers.put({
+              eventId,
+              speakerId: change.id,
+              addedAt: local?.addedAt ?? change.updatedAt,
+              ...merged,
+            });
+          }
+        }
+      }
+      for (const pushed of pendingSessions) {
+        const current = await cacheDB.interested.get([eventId, pushed.sessionId]);
+        const settled = current && settlePending(current, pushed.updatedAt);
+        if (settled) await cacheDB.interested.put({ ...current, ...settled });
+      }
+      for (const pushed of pendingSpeakers) {
+        const current = await cacheDB.interestedSpeakers.get([eventId, pushed.speakerId]);
+        const settled = current && settlePending(current, pushed.updatedAt);
+        if (settled) await cacheDB.interestedSpeakers.put({ ...current, ...settled });
+      }
+      await cacheDB.interestSync.put({ key: metaKey, lastSyncAt: now });
+    }
+  );
+
+  await mutate(["interested", eventId]);
+  await mutate(["interested-speakers", eventId]);
+}

--- a/event-app/src/data/interested/syncProtocol.ts
+++ b/event-app/src/data/interested/syncProtocol.ts
@@ -1,0 +1,58 @@
+/**
+ * Wire format of `POST /api/interests/sync`, shared by the route and the
+ * client runner (pure module). Times are ms since epoch; `since` and `now` are
+ * server-side cursors, `updatedAt` is the device's change time (last write
+ * wins per item).
+ */
+export const INTEREST_KINDS = ["session", "speaker"] as const;
+export type InterestKind = (typeof INTEREST_KINDS)[number];
+
+export interface InterestChange {
+  kind: InterestKind;
+  id: string;
+  /** False is a tombstone: the star was removed. */
+  interested: boolean;
+  updatedAt: number;
+}
+
+export interface SyncRequest {
+  event: string;
+  since: number | null;
+  changes: InterestChange[];
+}
+
+export interface SyncResponse {
+  changes: InterestChange[];
+  now: number;
+}
+
+export const MAX_CHANGES = 500;
+const EVENT_SHAPE = /^[a-z0-9-]{1,40}$/;
+const ID_SHAPE = /^[A-Za-z0-9_-]{1,120}$/;
+/** A device clock ahead of the server would otherwise win every conflict forever. */
+const MAX_FUTURE_MS = 60_000;
+
+/** Validate a request body; null when anything is off (the route answers 400). */
+export function parseSyncBody(body: unknown, now = Date.now()): SyncRequest | null {
+  if (!body || typeof body !== "object") return null;
+  const { event, since, changes } = body as Record<string, unknown>;
+  if (typeof event !== "string" || !EVENT_SHAPE.test(event)) return null;
+  if (since !== null && (typeof since !== "number" || !Number.isFinite(since) || since < 0)) return null;
+  if (!Array.isArray(changes) || changes.length > MAX_CHANGES) return null;
+  const parsed: InterestChange[] = [];
+  for (const raw of changes) {
+    if (!raw || typeof raw !== "object") return null;
+    const { kind, id, interested, updatedAt } = raw as Record<string, unknown>;
+    if (!INTEREST_KINDS.includes(kind as InterestKind)) return null;
+    if (typeof id !== "string" || !ID_SHAPE.test(id)) return null;
+    if (typeof interested !== "boolean") return null;
+    if (typeof updatedAt !== "number" || !Number.isFinite(updatedAt) || updatedAt < 0) return null;
+    parsed.push({
+      kind: kind as InterestKind,
+      id,
+      interested,
+      updatedAt: Math.min(Math.floor(updatedAt), now + MAX_FUTURE_MS),
+    });
+  }
+  return { event, since: since as number | null, changes: parsed };
+}

--- a/event-app/src/data/interested/useInterested.tsx
+++ b/event-app/src/data/interested/useInterested.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { toast } from "sonner";
 import { cacheDB } from "../cache/cache-db";
 import { getActiveDataset } from "../dataset";
+import { requestInterestSync } from "./sync";
 
 /**
  * "Interested" session stars. Browser-local user state persisted in the
@@ -24,7 +25,8 @@ export function useInterested() {
         .where("eventId")
         .equals(eventId)
         .toArray();
-      return rows.map((r) => r.sessionId);
+      // Tombstones (unstarred, kept for sync) are not stars.
+      return rows.filter((r) => r.interested !== false).map((r) => r.sessionId);
     },
     { revalidateOnFocus: false }
   );
@@ -46,16 +48,18 @@ export function useInterested() {
         cacheDB.interested,
         async () => {
           const existing = await cacheDB.interested.get(key);
-          if (existing) {
-            await cacheDB.interested.delete(key);
-            return false;
-          }
+          // Never delete: an unstar becomes a tombstone so the removal syncs
+          // to the account and wins by time on other devices (merge.ts).
+          const nowOn = !(existing?.interested ?? false);
           await cacheDB.interested.put({
             eventId,
             sessionId,
-            addedAt: Date.now(),
+            addedAt: existing?.addedAt ?? Date.now(),
+            interested: nowOn,
+            updatedAt: Date.now(),
+            pending: 1,
           });
-          return true;
+          return nowOn;
         }
       );
       if (added && title)
@@ -68,6 +72,7 @@ export function useInterested() {
           </span>
         );
       await mutate();
+      requestInterestSync();
     },
     [eventId, mutate]
   );

--- a/event-app/src/data/interested/useInterestedSpeakers.tsx
+++ b/event-app/src/data/interested/useInterestedSpeakers.tsx
@@ -5,6 +5,7 @@ import useSWR from "swr";
 import { toast } from "sonner";
 import { cacheDB } from "../cache/cache-db";
 import { getActiveDataset } from "../dataset";
+import { requestInterestSync } from "./sync";
 
 /**
  * "Interested" speaker stars (speakers page). Mirrors useInterested (session
@@ -23,7 +24,8 @@ export function useInterestedSpeakers() {
         .where("eventId")
         .equals(eventId)
         .toArray();
-      return rows.map((r) => r.speakerId);
+      // Tombstones (unstarred, kept for sync) are not stars.
+      return rows.filter((r) => r.interested !== false).map((r) => r.speakerId);
     },
     { revalidateOnFocus: false }
   );
@@ -45,16 +47,18 @@ export function useInterestedSpeakers() {
         cacheDB.interestedSpeakers,
         async () => {
           const existing = await cacheDB.interestedSpeakers.get(key);
-          if (existing) {
-            await cacheDB.interestedSpeakers.delete(key);
-            return false;
-          }
+          // Never delete: an unstar becomes a tombstone so the removal syncs
+          // to the account and wins by time on other devices (merge.ts).
+          const nowOn = !(existing?.interested ?? false);
           await cacheDB.interestedSpeakers.put({
             eventId,
             speakerId,
-            addedAt: Date.now(),
+            addedAt: existing?.addedAt ?? Date.now(),
+            interested: nowOn,
+            updatedAt: Date.now(),
+            pending: 1,
           });
-          return true;
+          return nowOn;
         }
       );
       if (added && name)
@@ -67,6 +71,7 @@ export function useInterestedSpeakers() {
           </span>
         );
       await mutate();
+      requestInterestSync();
     },
     [eventId, mutate]
   );

--- a/event-app/src/data/tickets/passBarcode.ts
+++ b/event-app/src/data/tickets/passBarcode.ts
@@ -1,0 +1,33 @@
+import { strFromU8, unzipSync } from "fflate";
+
+/**
+ * The QR payload of an Apple Wallet pass (`.pkpass`), read without rendering
+ * anything: the file is a zip whose `pass.json` lists its barcodes, and Pretix
+ * puts the position secret in the QR barcode's `message`. Null when the file
+ * is not a pass or carries no barcode. Pure, so it is unit-tested in node.
+ */
+export function readPassBarcode(zipBytes: Uint8Array): string | null {
+  let files: Record<string, Uint8Array>;
+  try {
+    files = unzipSync(zipBytes);
+  } catch {
+    return null;
+  }
+  const entry = files["pass.json"];
+  if (!entry) return null;
+  let pass: { barcodes?: unknown; barcode?: unknown };
+  try {
+    pass = JSON.parse(strFromU8(entry)) as typeof pass;
+  } catch {
+    return null;
+  }
+  const list = Array.isArray(pass.barcodes) ? pass.barcodes : pass.barcode ? [pass.barcode] : [];
+  const barcodes = list.filter(
+    (b): b is { message: string; format?: string } =>
+      !!b && typeof b === "object" && typeof (b as { message?: unknown }).message === "string"
+  );
+  // Prefer the QR entry; older passes have a single `barcode` of any format.
+  const chosen = barcodes.find((b) => /qr/i.test(b.format ?? "")) ?? barcodes[0];
+  const message = chosen?.message.trim();
+  return message ? message : null;
+}

--- a/event-app/src/data/tickets/primary.ts
+++ b/event-app/src/data/tickets/primary.ts
@@ -29,6 +29,33 @@ export function ticketPrompt(orders: Order[]): TicketPrompt {
 }
 
 /**
+ * One display order for every list of tickets (select rows, buyer chips):
+ * orders in the order they were placed, then by code, then tickets by Pretix
+ * position. Derived
+ * from the data rather than the payload order, so a chosen ticket moving to
+ * the front of the payload never reorders what people see.
+ */
+export function displayRank(orders: Order[]): Map<string, number> {
+  const info = new Map<string, { date: string; code: string }>();
+  for (const order of orders) {
+    if (!info.has(order.orderCode)) info.set(order.orderCode, { date: order.orderDate, code: order.orderCode });
+  }
+  // Chronological (oldest order first); same date (or none) falls back to the code.
+  const codes = [...info.values()]
+    .sort((a, b) => (a.date === b.date ? a.code.localeCompare(b.code) : a.date < b.date ? -1 : 1))
+    .map((entry) => entry.code);
+  const rank = new Map<string, number>();
+  for (const order of orders) {
+    const base = codes.indexOf(order.orderCode) * 1000;
+    order.tickets.forEach((ticket, index) => {
+      // Numbered tickets by position; unnumbered ones (fixture, stale cache) after them, in payload order.
+      rank.set(ticket.secret, base + (ticket.positionNumber ?? 100 + index));
+    });
+  }
+  return rank;
+}
+
+/**
  * User-facing ticket numbers, 1..n per order over every admission ticket the
  * account sees on that order (chosen one included, so numbers do not shift
  * after a choice). Pretix's own position numbers can have gaps once a ticket
@@ -75,10 +102,15 @@ export interface TicketChoice {
  */
 export function ticketChoices(orders: Order[]): TicketChoice[] {
   const ordinals = ticketOrdinals(orders);
-  return orders.flatMap((order) =>
-    order.tickets
-      .filter((ticket) => isAdmission(ticket) && !ticket.attached)
-      .map((ticket) => ({
+  const rank = displayRank(orders);
+  return orders
+    .flatMap((order) =>
+      order.tickets
+        .filter((ticket) => isAdmission(ticket) && !ticket.attached)
+        .map((ticket) => ({ order, ticket }))
+    )
+    .sort((a, b) => (rank.get(a.ticket.secret) ?? 0) - (rank.get(b.ticket.secret) ?? 0))
+    .map(({ order, ticket }) => ({
         positionId: ticket.positionId,
         ordinal: ordinals.get(ticket.secret) ?? 1,
         secret: ticket.secret,
@@ -88,8 +120,7 @@ export function ticketChoices(orders: Order[]): TicketChoice[] {
         orderCode: order.orderCode,
         sharedWith: ticket.sharedWith,
         test: ticket.test,
-      }))
-  );
+    }));
 }
 
 /** An order the account bought that still holds several admission tickets under its own email. */
@@ -112,6 +143,7 @@ export interface BuyerOrder {
  */
 export function buyerOrdersToAssign(orders: Order[]): BuyerOrder[] {
   const ordinals = ticketOrdinals(orders);
+  const rank = displayRank(orders);
   const byCode = new Map<string, BuyerOrder>();
   let total = 0;
   for (const order of orders) {
@@ -126,10 +158,13 @@ export function buyerOrdersToAssign(orders: Order[]): BuyerOrder[] {
     byCode.set(order.orderCode, entry);
   }
   if (total < 2) return [];
+  const firstRank = (entry: BuyerOrder) =>
+    Math.min(...entry.tickets.map((t) => rank.get(t.secret) ?? 0));
   return [...byCode.values()]
     .filter((entry) => entry.tickets.length > 0)
     .map((entry) => ({
       ...entry,
       tickets: [...entry.tickets].sort((a, b) => a.ordinal - b.ordinal),
-    }));
+    }))
+    .sort((a, b) => firstRank(a) - firstRank(b));
 }

--- a/event-app/src/data/tickets/primary.ts
+++ b/event-app/src/data/tickets/primary.ts
@@ -1,0 +1,135 @@
+import type { Order, Ticket } from "./types";
+
+/** `admission === false` is merchandise; undefined (older cache, unresolved item) still counts as a ticket. */
+export const isAdmission = (ticket: Ticket): boolean => ticket.admission !== false;
+
+/** Every admission ticket across orders, in server order (attached first). */
+export function admissionTickets(orders: Order[]): Ticket[] {
+  return orders.flatMap((order) => order.tickets.filter(isAdmission));
+}
+
+/**
+ * "My ticket" (spec: Account and attached ticket): the first attached
+ * admission ticket; else the only admission ticket matched by email; else
+ * none, and the ticket tab asks.
+ */
+export function derivePrimary(orders: Order[]): Ticket | null {
+  const tickets = admissionTickets(orders);
+  const attached = tickets.find((ticket) => ticket.attached);
+  if (attached) return attached;
+  return tickets.length === 1 ? tickets[0] : null;
+}
+
+export type TicketPrompt = "choose" | "none" | null;
+
+/** Which prompt the ticket tab shows when there is no primary ticket. */
+export function ticketPrompt(orders: Order[]): TicketPrompt {
+  if (derivePrimary(orders)) return null;
+  return admissionTickets(orders).length === 0 ? "none" : "choose";
+}
+
+/**
+ * User-facing ticket numbers, 1..n per order over every admission ticket the
+ * account sees on that order (chosen one included, so numbers do not shift
+ * after a choice). Pretix's own position numbers can have gaps once a ticket
+ * went to another holder, which read like a bug; these never do. Keyed by
+ * ticket secret.
+ */
+export function ticketOrdinals(orders: Order[]): Map<string, number> {
+  const byOrder = new Map<string, Ticket[]>();
+  for (const order of orders) {
+    const list = byOrder.get(order.orderCode) ?? [];
+    list.push(...order.tickets.filter(isAdmission));
+    byOrder.set(order.orderCode, list);
+  }
+  const ordinals = new Map<string, number>();
+  for (const list of byOrder.values()) {
+    list
+      .sort((a, b) => (a.positionNumber ?? 0) - (b.positionNumber ?? 0))
+      .forEach((ticket, index) => ordinals.set(ticket.secret, index + 1));
+  }
+  return ordinals;
+}
+
+/** One selectable row per admission ticket matched by email (the "Which ticket is yours?" list). */
+export interface TicketChoice {
+  /** Present for real Pretix positions; absent on payloads cached by older builds (not choosable until a refresh). */
+  positionId?: number;
+  /** User-facing number within its order (see ticketOrdinals). */
+  ordinal: number;
+  secret: string;
+  itemName: string;
+  holder: string;
+  addons: string[];
+  orderCode: string;
+  /** Other accounts that attached this ticket (its holder, most likely). */
+  sharedWith?: number;
+  /** Fixture ticket (dev/preview only). */
+  test?: boolean;
+}
+
+/**
+ * The account's email-matched admission tickets as choices. Attached tickets
+ * are excluded (the prompt only shows while none is attached anyway); order
+ * matches the server's.
+ */
+export function ticketChoices(orders: Order[]): TicketChoice[] {
+  const ordinals = ticketOrdinals(orders);
+  return orders.flatMap((order) =>
+    order.tickets
+      .filter((ticket) => isAdmission(ticket) && !ticket.attached)
+      .map((ticket) => ({
+        positionId: ticket.positionId,
+        ordinal: ordinals.get(ticket.secret) ?? 1,
+        secret: ticket.secret,
+        itemName: ticket.itemName,
+        holder: ticket.attendeeName || ticket.attendeeEmail,
+        addons: (ticket.addons ?? []).map((addon) => addon.itemName),
+        orderCode: order.orderCode,
+        sharedWith: ticket.sharedWith,
+        test: ticket.test,
+      }))
+  );
+}
+
+/** An order the account bought that still holds several admission tickets under its own email. */
+export interface BuyerOrder {
+  orderCode: string;
+  /** The Pretix order page, where attendee emails are changed (buyer only, see Order.url). */
+  url: string;
+  /** The admission tickets still under the buyer's email, in order, with their user-facing numbers. */
+  tickets: Array<{ secret: string; ordinal: number }>;
+}
+
+/**
+ * Tickets a buyer should hand over in Pretix: every email-matched admission
+ * ticket on orders the account placed (the order page URL is present), listed
+ * whenever the buyer holds more than one ticket in total, across orders, since
+ * at most one of them is their own. The chosen ticket stays in the list, so
+ * the block reads the same before and after choosing. Grouped by order code,
+ * because a chosen ticket and the rest of its order arrive as separate order
+ * objects.
+ */
+export function buyerOrdersToAssign(orders: Order[]): BuyerOrder[] {
+  const ordinals = ticketOrdinals(orders);
+  const byCode = new Map<string, BuyerOrder>();
+  let total = 0;
+  for (const order of orders) {
+    if (!order.url) continue;
+    const entry = byCode.get(order.orderCode) ?? { orderCode: order.orderCode, url: order.url, tickets: [] };
+    for (const ticket of order.tickets) {
+      // Real Pretix positions only: fixture tickets have no id and no page.
+      if (!isAdmission(ticket) || ticket.positionId === undefined) continue;
+      total++;
+      entry.tickets.push({ secret: ticket.secret, ordinal: ordinals.get(ticket.secret) ?? 1 });
+    }
+    byCode.set(order.orderCode, entry);
+  }
+  if (total < 2) return [];
+  return [...byCode.values()]
+    .filter((entry) => entry.tickets.length > 0)
+    .map((entry) => ({
+      ...entry,
+      tickets: [...entry.tickets].sort((a, b) => a.ordinal - b.ordinal),
+    }));
+}

--- a/event-app/src/data/tickets/qrDecode.ts
+++ b/event-app/src/data/tickets/qrDecode.ts
@@ -1,0 +1,118 @@
+import jsQR from "jsqr";
+
+/** Raw RGBA pixels, the shape `CanvasRenderingContext2D.getImageData` returns. */
+export interface RgbaImage {
+  data: Uint8ClampedArray;
+  width: number;
+  height: number;
+}
+
+/** Full-frame passes above this are wasted work: a QR fills a fraction of a screenshot. */
+const MAX_FULL_SIDE = 1600;
+/** Extra downsample passes: finder patterns show up at different scales. */
+const SCALE_PASSES = [1200, 800];
+
+/**
+ * Find a QR code in a screenshot (spec: decoded on the device). Passes,
+ * cheapest first: the frame capped at 1600px, two downsampled copies, then
+ * nine overlapping half-size crops so a small code in a corner still fills
+ * enough of the frame for jsQR. `attemptBoth` handles dark-mode tickets.
+ * Returns the decoded text, or null when no code was found.
+ */
+export function decodeQr(image: RgbaImage): string | null {
+  const base =
+    Math.max(image.width, image.height) > MAX_FULL_SIDE
+      ? downsample(image, MAX_FULL_SIDE)
+      : image;
+  const hit = scan(base);
+  if (hit) return hit;
+  for (const side of SCALE_PASSES) {
+    if (side >= Math.max(base.width, base.height)) continue;
+    const found = scan(downsample(base, side));
+    if (found) return found;
+  }
+  for (const tile of crops(base)) {
+    const found = scan(tile);
+    if (found) return found;
+  }
+  return null;
+}
+
+function scan(image: RgbaImage): string | null {
+  const result = jsQR(image.data, image.width, image.height, {
+    inversionAttempts: "attemptBoth",
+  });
+  const text = result?.data.trim();
+  return text ? text : null;
+}
+
+/** Box-filter downsample so `max(width, height) === maxSide`. */
+export function downsample(image: RgbaImage, maxSide: number): RgbaImage {
+  const scale = maxSide / Math.max(image.width, image.height);
+  const width = Math.max(1, Math.round(image.width * scale));
+  const height = Math.max(1, Math.round(image.height * scale));
+  const out = new Uint8ClampedArray(width * height * 4);
+  for (let y = 0; y < height; y++) {
+    const y0 = Math.floor((y * image.height) / height);
+    const y1 = Math.max(y0 + 1, Math.floor(((y + 1) * image.height) / height));
+    for (let x = 0; x < width; x++) {
+      const x0 = Math.floor((x * image.width) / width);
+      const x1 = Math.max(x0 + 1, Math.floor(((x + 1) * image.width) / width));
+      let r = 0;
+      let g = 0;
+      let b = 0;
+      let n = 0;
+      for (let sy = y0; sy < y1; sy++) {
+        let i = (sy * image.width + x0) * 4;
+        for (let sx = x0; sx < x1; sx++, i += 4) {
+          r += image.data[i];
+          g += image.data[i + 1];
+          b += image.data[i + 2];
+          n++;
+        }
+      }
+      const o = (y * width + x) * 4;
+      out[o] = r / n;
+      out[o + 1] = g / n;
+      out[o + 2] = b / n;
+      out[o + 3] = 255;
+    }
+  }
+  return { data: out, width, height };
+}
+
+/** Nine half-size tiles stepping by a quarter, so every point sits well inside at least one tile. */
+export function crops(image: RgbaImage): RgbaImage[] {
+  const w = Math.floor(image.width / 2);
+  const h = Math.floor(image.height / 2);
+  const tiles: RgbaImage[] = [];
+  for (let row = 0; row < 3; row++) {
+    for (let col = 0; col < 3; col++) {
+      tiles.push(
+        crop(
+          image,
+          Math.floor((col * image.width) / 4),
+          Math.floor((row * image.height) / 4),
+          w,
+          h
+        )
+      );
+    }
+  }
+  return tiles;
+}
+
+export function crop(
+  image: RgbaImage,
+  x: number,
+  y: number,
+  width: number,
+  height: number
+): RgbaImage {
+  const out = new Uint8ClampedArray(width * height * 4);
+  for (let row = 0; row < height; row++) {
+    const src = ((y + row) * image.width + x) * 4;
+    out.set(image.data.subarray(src, src + width * 4), row * width * 4);
+  }
+  return { data: out, width, height };
+}

--- a/event-app/src/data/tickets/qrFromFile.ts
+++ b/event-app/src/data/tickets/qrFromFile.ts
@@ -1,0 +1,145 @@
+import { decodeQr, type RgbaImage } from "./qrDecode";
+import { readPassBarcode } from "./passBarcode";
+
+/** Longest side drawn to the canvas; phone screenshots are ~1200x2600. */
+const MAX_SIDE = 2000;
+/** A ticket PDF puts the QR on the first page; a couple more covers multi-ticket exports. */
+const MAX_PDF_PAGES = 3;
+
+/** What the picker offers: screenshots and photos, the ticket PDF, the wallet pass. */
+export const ACCEPTED_TICKET_FILES =
+  "image/*,.pdf,application/pdf,.pkpass,application/vnd.apple.pkpass";
+
+/**
+ * Image formats a browser may refuse to decode: HEIC/HEIF (iPhone photos)
+ * outside Safari, TIFF almost everywhere. Used for a specific failure message.
+ */
+export function isUnsupportedPhotoFormat(file: Blob): boolean {
+  const name = "name" in file ? String((file as File).name).toLowerCase() : "";
+  const type = file.type.toLowerCase();
+  return (
+    /^image\/(heic|heif|tiff)/.test(type) ||
+    /\.(heic|heif|tif|tiff)$/.test(name)
+  );
+}
+
+/**
+ * Read a ticket's QR payload from a picked file (browser only; imported
+ * dynamically by the attach card so none of this is in the main bundle):
+ * - an image (screenshot, photo): scanned with jsQR;
+ * - a `.pkpass` wallet pass: the payload is text inside the zip, no scan;
+ * - a PDF: pages rendered with pdf.js (loaded on demand) and scanned.
+ * Null when nothing decodes.
+ */
+export async function decodeQrFromFile(file: Blob): Promise<string | null> {
+  switch (fileKind(file)) {
+    case "pkpass":
+      return readPassBarcode(new Uint8Array(await file.arrayBuffer()));
+    case "pdf":
+      return decodeFromPdf(file);
+    default:
+      return decodeFromImage(file);
+  }
+}
+
+function fileKind(file: Blob): "pkpass" | "pdf" | "image" {
+  const name = "name" in file ? String((file as File).name).toLowerCase() : "";
+  const type = file.type.toLowerCase();
+  if (type === "application/vnd.apple.pkpass" || name.endsWith(".pkpass")) return "pkpass";
+  if (type === "application/pdf" || name.endsWith(".pdf")) return "pdf";
+  return "image";
+}
+
+function scanCanvas(canvas: HTMLCanvasElement, ctx: CanvasRenderingContext2D): string | null {
+  const { data } = ctx.getImageData(0, 0, canvas.width, canvas.height);
+  const image: RgbaImage = { data, width: canvas.width, height: canvas.height };
+  return decodeQr(image);
+}
+
+async function decodeFromImage(file: Blob): Promise<string | null> {
+  const source = await loadImage(file);
+  if (!source) return null;
+  try {
+    const scale = Math.min(1, MAX_SIDE / Math.max(source.width, source.height));
+    const canvas = document.createElement("canvas");
+    canvas.width = Math.max(1, Math.round(source.width * scale));
+    canvas.height = Math.max(1, Math.round(source.height * scale));
+    const ctx = canvas.getContext("2d", { willReadFrequently: true });
+    if (!ctx) return null;
+    ctx.drawImage(source.bitmap, 0, 0, canvas.width, canvas.height);
+    return scanCanvas(canvas, ctx);
+  } finally {
+    source.release();
+  }
+}
+
+async function decodeFromPdf(file: Blob): Promise<string | null> {
+  // Legacy build: the modern one needs Promise.withResolvers, missing from
+  // iOS before 17.4. The worker ships as a static asset via the URL import.
+  const pdfjs = await import("pdfjs-dist/legacy/build/pdf.mjs");
+  pdfjs.GlobalWorkerOptions.workerSrc = new URL(
+    "pdfjs-dist/legacy/build/pdf.worker.min.mjs",
+    import.meta.url
+  ).toString();
+  const task = pdfjs.getDocument({ data: new Uint8Array(await file.arrayBuffer()) });
+  const doc = await task.promise;
+  try {
+    const pages = Math.min(doc.numPages, MAX_PDF_PAGES);
+    for (let number = 1; number <= pages; number++) {
+      const page = await doc.getPage(number);
+      const base = page.getViewport({ scale: 1 });
+      const viewport = page.getViewport({ scale: MAX_SIDE / Math.max(base.width, base.height) });
+      const canvas = document.createElement("canvas");
+      canvas.width = Math.ceil(viewport.width);
+      canvas.height = Math.ceil(viewport.height);
+      const ctx = canvas.getContext("2d", { willReadFrequently: true });
+      if (!ctx) return null;
+      await page.render({ canvasContext: ctx, canvas, viewport }).promise;
+      const found = scanCanvas(canvas, ctx);
+      page.cleanup();
+      if (found) return found;
+    }
+    return null;
+  } finally {
+    // Tears down the document and its worker.
+    await task.destroy();
+  }
+}
+
+interface LoadedImage {
+  bitmap: CanvasImageSource;
+  width: number;
+  height: number;
+  release(): void;
+}
+
+async function loadImage(file: Blob): Promise<LoadedImage | null> {
+  if (typeof createImageBitmap === "function") {
+    try {
+      const bitmap = await createImageBitmap(file);
+      return {
+        bitmap,
+        width: bitmap.width,
+        height: bitmap.height,
+        release: () => bitmap.close(),
+      };
+    } catch {
+      // Fall through: some Safari builds reject certain PNGs here.
+    }
+  }
+  const url = URL.createObjectURL(file);
+  try {
+    const img = new Image();
+    img.src = url;
+    await img.decode();
+    return {
+      bitmap: img,
+      width: img.naturalWidth,
+      height: img.naturalHeight,
+      release: () => URL.revokeObjectURL(url),
+    };
+  } catch {
+    URL.revokeObjectURL(url);
+    return null;
+  }
+}

--- a/event-app/src/data/tickets/types.ts
+++ b/event-app/src/data/tickets/types.ts
@@ -19,6 +19,8 @@ export interface TicketAddon {
   active?: boolean;
   /** Pretix item `picture` URL, shown on the swag card. */
   imageUrl?: string;
+  /** Pretix has a check-in on this add-on position: the swag was handed over. */
+  collected?: boolean;
 }
 
 /** A single attendee ticket within an order. `secret` encodes the QR code. */
@@ -43,6 +45,16 @@ export interface Ticket {
   imageUrl?: string;
   /** Server-pinned card style (env item-id override); client falls back to name matching. */
   style?: TicketStyle;
+  /** Pretix order position id: the handle for attach and detach. Absent on fixture tickets. */
+  positionId?: number;
+  /** Pretix's per-order position number (1-based), the one printed on the ticket. */
+  positionNumber?: number;
+  /** True when the account proved it holds this ticket (QR screenshot), rather than matching by email. */
+  attached?: boolean;
+  /** Other accounts that attached this same ticket; only one person can enter with it. */
+  sharedWith?: number;
+  /** Fixture ticket from TICKET_TEST_INDIA_ORDER_CODE (dev/preview only): never a real Pretix position. */
+  test?: boolean;
 }
 
 /** A paid Pretix order, holding one or more tickets. */
@@ -50,15 +62,27 @@ export interface Order {
   orderCode: string;
   orderDate: string;
   email: string;
+  /**
+   * Pretix order page (carries the order secret). Only present when the
+   * signed-in account is the buyer, since that page manages the whole order.
+   */
+  url?: string;
   eventName?: string;
   eventSlug?: string;
   eventId?: number | null;
   tickets: Ticket[];
 }
 
+/** Body of a successful `/api/tickets` (and attach/detach) response. */
+export interface TicketsPayload {
+  tickets: Order[];
+  /** Attached tickets Pretix no longer verifies (refunded, reissued); their links were removed on this fetch. */
+  removedAttachments?: number;
+}
+
 /** Shape returned by the `/api/tickets` route. */
 export interface TicketsResponse {
   success: boolean;
-  data?: { tickets: Order[] };
+  data?: TicketsPayload;
   error?: string;
 }

--- a/event-app/src/data/tickets/useTickets.ts
+++ b/event-app/src/data/tickets/useTickets.ts
@@ -1,15 +1,25 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import useSWR from "swr";
 import QRCode from "qrcode";
 import { supabase } from "@/data/auth/supabase";
 import { useUser } from "@/data/auth/useUser";
 import { isTransientFetchError, retryOnce } from "@/utils/retryOnce";
-import type { Order, TicketsResponse } from "./types";
+import { derivePrimary, ticketPrompt } from "./primary";
+import type { TicketsPayload, TicketsResponse } from "./types";
 
 /** Pause before the single automatic retry of a dropped first request. */
 const RETRY_DELAY_MS = 1_000;
+
+async function accessToken(): Promise<string> {
+  if (!supabase) throw new Error("Supabase not initialized");
+  const {
+    data: { session },
+  } = await supabase.auth.getSession();
+  if (!session?.access_token) throw new Error("Not signed in");
+  return session.access_token;
+}
 
 /**
  * Fetch the signed-in user's tickets from `/api/tickets`, sending the Supabase
@@ -20,14 +30,8 @@ const RETRY_DELAY_MS = 1_000;
  * tickets, so a single dropped request used to flash red before the next
  * attempt succeeded. Application errors are not retried.
  */
-async function fetchTickets(): Promise<{ tickets: Order[] }> {
-  if (!supabase) throw new Error("Supabase not initialized");
-  const {
-    data: { session },
-  } = await supabase.auth.getSession();
-  const token = session?.access_token;
-  if (!token) throw new Error("Not signed in");
-
+async function fetchTickets(): Promise<TicketsPayload> {
+  const token = await accessToken();
   return retryOnce(
     async () => {
       const res = await fetch("/api/tickets", {
@@ -44,6 +48,32 @@ async function fetchTickets(): Promise<{ tickets: Order[] }> {
   );
 }
 
+export type AttachResult = { ok: true } | { ok: false; error: string };
+
+/** POST (attach) or DELETE (detach) against the attach route; resolves with the new payload or the server's message. */
+async function attachRequest(
+  method: "POST" | "DELETE",
+  body: Record<string, unknown>
+): Promise<{ ok: true; data: TicketsPayload } | { ok: false; error: string }> {
+  try {
+    const res = await fetch("/api/tickets/attach", {
+      method,
+      headers: {
+        Authorization: `Bearer ${await accessToken()}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify(body),
+    });
+    const json: TicketsResponse = await res.json();
+    if (!json.success || !json.data) {
+      return { ok: false, error: json.error || "Couldn't attach the ticket, try again" };
+    }
+    return { ok: true, data: json.data };
+  } catch {
+    return { ok: false, error: "Couldn't reach the server, check your connection" };
+  }
+}
+
 /**
  * Reusable hook for the user's tickets.
  *
@@ -51,8 +81,12 @@ async function fetchTickets(): Promise<{ tickets: Order[] }> {
  * `src/data/cache`), so tickets remain available offline after the first load.
  * Only fetches once a user is signed in.
  *
- * Returns the orders, a map of `secret -> QR data URL`, loading/error state and
- * a `refresh()` that revalidates.
+ * Returns the orders, the primary ticket ("my ticket", see primary.ts) and
+ * which prompt the ticket tab should show, a map of `secret -> QR data URL`,
+ * loading/error state, a `refresh()` that revalidates, and `attach` (QR
+ * screenshot), `choose` (one of the email-matched tickets) and `detach`, all
+ * of which replace the cached payload with the server's answer, no second
+ * fetch.
  */
 export function useTickets() {
   const { user, hasInitialized } = useUser();
@@ -70,6 +104,41 @@ export function useTickets() {
     !hasInitialized || (!!user && data === undefined && error === undefined);
 
   const tickets = data?.tickets ?? [];
+  const primary = useMemo(() => derivePrimary(data?.tickets ?? []), [data]);
+  const prompt = useMemo(() => ticketPrompt(data?.tickets ?? []), [data]);
+
+  const [attaching, setAttaching] = useState(false);
+  const attach = async (code: string): Promise<AttachResult> => {
+    setAttaching(true);
+    try {
+      const result = await attachRequest("POST", { code });
+      if (result.ok) await mutate(result.data, { revalidate: false });
+      return result.ok ? { ok: true } : result;
+    } finally {
+      setAttaching(false);
+    }
+  };
+  /** "This one is mine" among the email-matched tickets: no QR needed. */
+  const choose = async (positionId: number): Promise<AttachResult> => {
+    setAttaching(true);
+    try {
+      const result = await attachRequest("POST", { positionId });
+      if (result.ok) await mutate(result.data, { revalidate: false });
+      return result.ok ? { ok: true } : result;
+    } finally {
+      setAttaching(false);
+    }
+  };
+  const detach = async (positionId: number): Promise<AttachResult> => {
+    setAttaching(true);
+    try {
+      const result = await attachRequest("DELETE", { positionId });
+      if (result.ok) await mutate(result.data, { revalidate: false });
+      return result.ok ? { ok: true } : result;
+    } finally {
+      setAttaching(false);
+    }
+  };
 
   // Derive QR codes from the (cached) ticket secrets — no network needed, so
   // they regenerate offline from the persisted data.
@@ -109,11 +178,19 @@ export function useTickets() {
 
   return {
     tickets,
+    primary,
+    prompt,
+    /** Attached tickets Pretix no longer verified on the last fetch (their links were removed). */
+    removedAttachments: data?.removedAttachments ?? 0,
     qrCodes,
     isLoading: loading,
     /** True during a background revalidation (e.g. Refresh) when data exists. */
     isRefreshing: isValidating && data !== undefined,
     error: error as Error | undefined,
     refresh: () => mutate(),
+    attach,
+    choose,
+    detach,
+    attaching,
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1840,9 +1840,15 @@ importers:
       dexie:
         specifier: ^4.2.1
         version: 4.2.1
+      fflate:
+        specifier: ^0.8.3
+        version: 0.8.3
       framer-motion:
         specifier: 12.0.0-alpha.1
         version: 12.0.0-alpha.1(@emotion/is-prop-valid@1.4.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      jsqr:
+        specifier: ^1.4.0
+        version: 1.4.0
       lib:
         specifier: workspace:*
         version: link:../lib
@@ -1855,6 +1861,9 @@ importers:
       panzoom:
         specifier: ^9.4.3
         version: 9.4.3
+      pdfjs-dist:
+        specifier: ^6.3.289
+        version: 6.3.289
       qrcode:
         specifier: ^1.5.4
         version: 1.5.4
@@ -4897,8 +4906,8 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0
 
-  '@graphql-codegen/plugin-helpers@7.2.1':
-    resolution: {integrity: sha512-Jw2HPaioMEa4DKG7sgqzL1uWQiIWQu774FwKXx4p83/y3o5GgnRMRdTFtuQQ7Tq6PYyrI5ZITi1jAxeX/Vh2Uw==}
+  '@graphql-codegen/plugin-helpers@7.3.0':
+    resolution: {integrity: sha512-aaGfI/8Q8wmdO1nx1NMWGoZn/5Tl5TNOVQSI2qkGhk8h8Z8Uc6grFH0O6//HdHfqnUsiruBbe3IaK4/ah3sWcQ==}
     engines: {node: '>=16'}
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
@@ -5803,6 +5812,76 @@ packages:
     resolution: {integrity: sha512-3fkKj25kEjsfObL6IlKPAlHYPq/oYwUkkQ03zsTTiDjD7vg/RxjdiLeCydqtxHZP0JgsXL3D/X5oAkMGzuUp/Q==}
     engines: {node: '>=12'}
 
+  '@napi-rs/canvas-android-arm64@1.0.9':
+    resolution: {integrity: sha512-4LGXk2/0HVzE29K8SzML5WubgCp++B1FH3qgl35XmSZE+lLdr6P9VRQEnZ0MCLZMTSuJP41yyhtoiVNEuvrTIA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [android]
+
+  '@napi-rs/canvas-darwin-arm64@1.0.9':
+    resolution: {integrity: sha512-YNdfLBzY0W/Pep9fo2L6RmoNlNksnn05LRnX66W63R3ij58S25QOTcjdtEt2v8+PnCESzqZsYzUo+QPeIR44NA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@napi-rs/canvas-darwin-x64@1.0.9':
+    resolution: {integrity: sha512-ceZQSknTEcy3dOXoekv59LTCkXjvnLsq+VW5PeNNDHEPQbRS5Ervkm1EaDa7WLAjiYWMLuSQTRTHao1dEX4prg==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.9':
+    resolution: {integrity: sha512-XhfI0Wwv4llhd6nnWDtY3kQKjq0r+y1i91PlJlJI24ag2U9WrnwbG1qS3+fDLEyouwEVFchiKkTEHozK+5iUNA==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.9':
+    resolution: {integrity: sha512-012oiYtKaE7i9oxc8q7nraT7kDOpLcaCmFLzVe9Ty34RHDdoDzbWLrVh827CNxYh/EADX1eSikA3ymLjo/nNuw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.9':
+    resolution: {integrity: sha512-Ls5UWYFFn63casTZEczbeyEg3vRDRkv9lscuGwfchtY5yLLQhgOB8SN4YGxmfJ5vTaBwZ2YUxBS3NtmjJmFXdA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.9':
+    resolution: {integrity: sha512-hLKEGxV7ZiRHqndePTokgDMdBlo/rDfzg7P4p4QIv9pUhuYobnu3R2NIFLCRghG0nwfo+s2sw+c1xZFeCmEAsw==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.9':
+    resolution: {integrity: sha512-6kaz3w0QMy77PDWk6rJ1ksIihdad3qzEyX2o2oGT8GwCaypfT5mhjr8buOO5hstyLxcWXDScuz56RsINLtBPIQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.9':
+    resolution: {integrity: sha512-xrGvmS3v55hmZ86ls/kBLVNMUTYio3f6Ik0DireemG994VfPAwiA3ZXA0Uf1bByctkB3NQ1Sfb+H5bkdUnnzfQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.9':
+    resolution: {integrity: sha512-yjmVS3ArZeRVCP7jqbPq4rpZa/BhTeI7ELE2XqJg3snICQBDevLZyArxswHkiTnT34KRic33/4fLirrHI+SY8A==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.9':
+    resolution: {integrity: sha512-QlSYQdMQslB81nlABo9wNfQ6npFhE7/O+saCZdqVGueGanyRk4jCogD5EwQenfP3kIq9e+mm6GreQBjX5MrA8g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@napi-rs/canvas@1.0.9':
+    resolution: {integrity: sha512-QviPdJImDi/jMAvBfqaw+19BndMd/sizXVW3NnpMd3VJGz++QXkOHcP9kWR/smHG0hNjHeyuHFyrx/5lD0oNcQ==}
+    engines: {node: '>= 10'}
+
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     resolution: {integrity: sha512-oTXEIha4SsuXdTA4Iyskj0kpdx2yVXdhd75c2v3xGrHFfVMsbhTPZU/nMPL4sWKo4pBHm3aucLaqGlF696dTyQ==}
     engines: {node: ^22.20 || ^24.12 || >=25}
@@ -6574,7 +6653,7 @@ packages:
 
   '@paulmillr/qr@0.2.1':
     resolution: {integrity: sha512-IHnV6A+zxU7XwmKFinmYjUcwlyK9+xkG3/s9KcQhI9BjQKycrJ1JRO+FbNYPwZiPKW3je/DR0k7w8/gLa5eaxQ==}
-    deprecated: 'Switch to "qr" (new package name) for security updates: npm install qr'
+    deprecated: 'The package is now available as "qr": npm install qr'
 
   '@pcd/gpc@0.4.1':
     resolution: {integrity: sha512-ltdoAe3+umiKoqVoiLL2lAvXD9svbVXkCczv9qDg6qd9M9GUzzSKDImeBfDUZHhotekg8g5acOCDbREBrqZg6A==}
@@ -15105,6 +15184,9 @@ packages:
   fflate@0.8.2:
     resolution: {integrity: sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==}
 
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
+
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
     engines: {node: '>=18'}
@@ -15533,7 +15615,7 @@ packages:
   git-raw-commits@2.0.11:
     resolution: {integrity: sha512-VnctFhw+xfj8Va1xtfEqCUD2XDrbAPSJx+hSrE5K7fGdjZruW7XV+QOrN7LF/RJyvspRiD2I0asWsxFp0ya26A==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   git-remote-origin-url@2.0.0:
@@ -15543,7 +15625,7 @@ packages:
   git-semver-tags@4.1.1:
     resolution: {integrity: sha512-OWyMt5zBe7xFs8vglMmhM9lRQzCWL3WjHtxNNfJTMngGym7pC1kh8sP6jevfydJ6LP3ZvGxfb6ABYgPUM0mtsA==}
     engines: {node: '>=10'}
-    deprecated: Deprecated and no longer maintained. Use @conventional-changelog/git-client instead.
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   gitconfiglocal@1.0.0:
@@ -19742,6 +19824,10 @@ packages:
   pbkdf2@3.1.6:
     resolution: {integrity: sha512-BT6eelPB1EyGHo8pC0o9Bl6k6SYVhKO1jEbd3lcTrtr7XHdjP8BW1YpfCV3G9Kwkxgattk+S5q2/RvuttCsS1g==}
     engines: {node: '>= 0.10'}
+
+  pdfjs-dist@6.3.289:
+    resolution: {integrity: sha512-ZHjSVpDa3D6izMq8/04lvkhkATUmL9px6ChPaXc1k6nU2Mrhlg1/7F0bdUqCwUjw3NsPTfPZsMDUU6ZIcRaeQw==}
+    engines: {node: '>=22.13.0 || >=24'}
 
   peberminta@0.9.0:
     resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
@@ -29463,7 +29549,7 @@ snapshots:
       lodash: 4.17.21
       tslib: 2.6.3
 
-  '@graphql-codegen/plugin-helpers@7.2.1(graphql@15.8.0)':
+  '@graphql-codegen/plugin-helpers@7.3.0(graphql@15.8.0)':
     dependencies:
       '@graphql-tools/utils': 11.2.2(graphql@15.8.0)
       change-case-all: 2.1.0
@@ -30903,6 +30989,54 @@ snapshots:
       strict-event-emitter: 0.5.1
 
   '@n1ru4l/push-pull-async-iterable-iterator@3.2.0': {}
+
+  '@napi-rs/canvas-android-arm64@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-darwin-arm64@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-darwin-x64@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm-gnueabihf@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-gnu@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-arm64-musl@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-riscv64-gnu@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-gnu@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-linux-x64-musl@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-win32-arm64-msvc@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas-win32-x64-msvc@1.0.9':
+    optional: true
+
+  '@napi-rs/canvas@1.0.9':
+    optionalDependencies:
+      '@napi-rs/canvas-android-arm64': 1.0.9
+      '@napi-rs/canvas-darwin-arm64': 1.0.9
+      '@napi-rs/canvas-darwin-x64': 1.0.9
+      '@napi-rs/canvas-linux-arm-gnueabihf': 1.0.9
+      '@napi-rs/canvas-linux-arm64-gnu': 1.0.9
+      '@napi-rs/canvas-linux-arm64-musl': 1.0.9
+      '@napi-rs/canvas-linux-riscv64-gnu': 1.0.9
+      '@napi-rs/canvas-linux-x64-gnu': 1.0.9
+      '@napi-rs/canvas-linux-x64-musl': 1.0.9
+      '@napi-rs/canvas-win32-arm64-msvc': 1.0.9
+      '@napi-rs/canvas-win32-x64-msvc': 1.0.9
+    optional: true
 
   '@napi-rs/lzma-linux-x64-gnu@1.5.1':
     optional: true
@@ -32848,7 +32982,7 @@ snapshots:
       debug: 4.4.3
       invariant: 2.2.4
       metro: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.82.5
       semver: 7.8.5
     transitivePeerDependencies:
@@ -38790,7 +38924,7 @@ snapshots:
   '@tinacms/cli@1.10.1(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.1.8))(@types/node@20.19.9)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(abstract-level@1.0.4)(encoding@0.1.13)(immer@10.2.0)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react-native@0.80.2(@babel/core@7.28.0)(@types/react@19.1.8)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(rollup@4.62.4)(sass@1.44.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.0)(terser@5.50.0)(ts-node@10.9.1(@swc/core@1.13.5)(@types/node@20.19.9)(typescript@5.8.3))(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
       '@graphql-codegen/core': 2.6.8(graphql@15.8.0)
-      '@graphql-codegen/plugin-helpers': 7.2.1(graphql@15.8.0)
+      '@graphql-codegen/plugin-helpers': 7.3.0(graphql@15.8.0)
       '@graphql-codegen/typescript': 4.1.6(encoding@0.1.13)(graphql@15.8.0)
       '@graphql-codegen/typescript-operations': 4.6.1(encoding@0.1.13)(graphql@15.8.0)
       '@graphql-codegen/visitor-plugin-common': 4.1.2(encoding@0.1.13)(graphql@15.8.0)
@@ -38872,7 +39006,7 @@ snapshots:
   '@tinacms/cli@1.10.1(@codemirror/language@6.0.0)(@types/hoist-non-react-statics@3.3.7(@types/react@19.1.8))(@types/node@20.19.9)(@types/react-dom@19.1.6(@types/react@19.1.8))(@types/react@19.1.8)(abstract-level@1.0.4)(encoding@0.1.13)(immer@10.2.0)(lightningcss@1.30.1)(react-dom@19.2.3(react@19.2.3))(react-native@0.80.2(@babel/core@7.28.4)(@types/react@19.1.8)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@5.0.10))(react@19.2.3)(rollup@2.79.2)(sass@1.44.0)(scheduler@0.27.0)(slate-dom@0.114.0(slate@0.114.0))(slate@0.114.0)(sucrase@3.35.0)(terser@5.50.0)(ts-node@10.9.1(@swc/core@1.13.5)(@types/node@20.19.9)(typescript@5.8.3))(use-sync-external-store@1.6.0(react@19.2.3))':
     dependencies:
       '@graphql-codegen/core': 2.6.8(graphql@15.8.0)
-      '@graphql-codegen/plugin-helpers': 7.2.1(graphql@15.8.0)
+      '@graphql-codegen/plugin-helpers': 7.3.0(graphql@15.8.0)
       '@graphql-codegen/typescript': 4.1.6(encoding@0.1.13)(graphql@15.8.0)
       '@graphql-codegen/typescript-operations': 4.6.1(encoding@0.1.13)(graphql@15.8.0)
       '@graphql-codegen/visitor-plugin-common': 4.1.2(encoding@0.1.13)(graphql@15.8.0)
@@ -51036,7 +51170,7 @@ snapshots:
       eslint: 8.8.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.8.0)
       eslint-plugin-react: 7.37.5(eslint@8.8.0)
       eslint-plugin-react-hooks: 4.6.2(eslint@8.8.0)
@@ -51093,7 +51227,7 @@ snapshots:
       eslint: 8.8.0
       eslint-import-resolver-node: 0.3.9
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.8.0)
       eslint-plugin-react: 7.37.5(eslint@8.8.0)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.8.0)
@@ -51180,7 +51314,7 @@ snapshots:
     dependencies:
       debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.8.0
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.8.0)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0)
       glob: 7.2.3
       is-glob: 4.0.3
       resolve: 1.22.10
@@ -51380,7 +51514,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1)(eslint@8.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@5.62.0(eslint@8.8.0)(typescript@5.8.3))(eslint-import-resolver-typescript@2.7.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -51438,7 +51572,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1)(eslint@8.8.0):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@6.21.0(eslint@8.8.0)(typescript@5.2.2))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(eslint@8.8.0))(eslint@8.8.0))(eslint@8.8.0):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -52723,6 +52857,8 @@ snapshots:
   fflate@0.7.4: {}
 
   fflate@0.8.2: {}
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -56349,6 +56485,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  metro-config@0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
+    dependencies:
+      connect: 3.7.0
+      cosmiconfig: 5.2.1
+      flow-enums-runtime: 0.0.6
+      jest-validate: 29.7.0
+      metro: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
+      metro-cache: 0.82.5
+      metro-core: 0.82.5
+      metro-runtime: 0.82.5
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   metro-config@0.82.5(bufferutil@4.1.0)(utf-8-validate@5.0.10):
     dependencies:
       connect: 3.7.0
@@ -56363,6 +56514,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro-core@0.82.5:
     dependencies:
@@ -56474,6 +56626,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   metro@0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10):
     dependencies:
@@ -56501,7 +56654,7 @@ snapshots:
       metro-babel-transformer: 0.82.5
       metro-cache: 0.82.5
       metro-cache-key: 0.82.5
-      metro-config: 0.82.5(bufferutil@4.1.0)(utf-8-validate@5.0.10)
+      metro-config: 0.82.5(bufferutil@4.0.9)(utf-8-validate@5.0.10)
       metro-core: 0.82.5
       metro-file-map: 0.82.5
       metro-resolver: 0.82.5
@@ -56568,6 +56721,7 @@ snapshots:
       - bufferutil
       - supports-color
       - utf-8-validate
+    optional: true
 
   micro-ftch@0.3.1: {}
 
@@ -58970,6 +59124,10 @@ snapshots:
       safe-buffer: 5.2.1
       sha.js: 2.4.12
       to-buffer: 1.2.2
+
+  pdfjs-dist@6.3.289:
+    optionalDependencies:
+      '@napi-rs/canvas': 1.0.9
 
   peberminta@0.9.0: {}
 

--- a/scripts/offline-sweep.mjs
+++ b/scripts/offline-sweep.mjs
@@ -185,9 +185,23 @@ check("unknown route offline shows the fallback", /offline/i.test((await page.lo
 // Cross-section trip with no document reload. A marker on `window` survives
 // pushState/popstate navigations but not a real document load, so its
 // presence at the end proves every step was a client-side transition.
-await page.goto(`${base}/schedule?${q}`, { waitUntil: "load" });
+const tripResponse = await page.goto(`${base}/schedule?${q}`, { waitUntil: "load" });
 await page.waitForFunction((sel) => document.querySelectorAll(sel).length > 0, SESSION_LINK, { timeout: 15000 }).catch(async () => {
   console.log("DIAG offline /schedule without cards:", await page.evaluate(() => document.body.innerText.slice(0, 300).replace(/\n+/g, " | ")));
+  console.log("DIAG response:", tripResponse ? `${tripResponse.status()} fromSW=${tripResponse.fromServiceWorker()}` : "none");
+  console.log("DIAG caches:", JSON.stringify(await page.evaluate(async () => {
+    const out = {};
+    for (const name of await caches.keys()) {
+      const keys = await (await caches.open(name)).keys();
+      const paths = keys.map((r) => new URL(r.url).pathname);
+      out[name] = { count: keys.length, hasSchedule: paths.includes("/schedule"), hasOffline: paths.includes("/offline") };
+    }
+    out.matchSchedule = !!(await caches.match(`${location.origin}/schedule`, { ignoreSearch: true }));
+    out.controller = navigator.serviceWorker?.controller?.scriptURL ?? null;
+    const reg = await navigator.serviceWorker?.getRegistration();
+    out.states = reg ? { active: reg.active?.state, waiting: reg.waiting?.state, installing: reg.installing?.state } : null;
+    return out;
+  })));
 });
 await page.evaluate(() => {
   window.__dcSweep = true;


### PR DESCRIPTION
**What shipped on `event-app-ticket-rework`**

**One ticket per account.** Sign-in stays the email OTP, but the app now settles whose ticket is whose. If your email matches one ticket, nothing changes. If it matches several, the ticket tab asks "Which ticket is yours?" and shows no QR codes until you pick one; if it matches none, you upload your ticket instead. Uploads take a screenshot or photo, the ticket PDF, or the wallet pass, all decoded on your device; the server verifies the code against Pretix and stores only a hash. The chosen or uploaded ticket becomes your primary: it is the only ticket shown, its swag and perk follow it, Q&A eligibility counts it, and it syncs across your devices. A ticket picked from the list is dropped automatically if the buyer later reassigns it in Pretix; a ticket uploaded by QR shows the holder as the account, never the buyer.

**Buyers get nudged.** Anyone whose email is the buyer on more than one ticket sees a "Bought tickets for others?" block linking each ticket straight to the Pretix form where attendee emails are set. The same nudge goes out by email before the event (screenshot 👇 for copy review).

<img width="2016" height="1872" alt="Screenshot 2026-09-10 at 20 37 39" src="https://github.com/user-attachments/assets/82bb01d0-967a-4e02-8e62-51ff50a9bb10" />

**Interests sync.** Stars stay on the device and, when signed in, sync to the account so every device shows the same ones. Conflicts resolve last write wins per item; unstarring propagates; stars stay on the device after sign-out.

**Swag pickup.** Swag cards and the enlarged QR show "Collected" once the item was scanned at the swag station.

**Smaller things.** Tickets are numbered for people ("`Order ABCDE · Ticket #1`", printed on the card, in the list and in the buyer links) with a consistent chronological order everywhere; a ticket attached to more than one account says so; offline, the saved tickets stay reachable even before a choice is made.

**Verified** with type checks, unit tests, the offline sweep, a real-browser decode harness for all three upload formats, live Pretix probes and manual tests on phone and desktop. Three database migrations are applied.

**Accepted trade-offs.** Two accounts may attach the same ticket; the door decides and the app says so. A holder of two legitimate tickets sees one; the other stays in the Pretix email.